### PR TITLE
タスク管理画面のUI改善とガントチャート刷新

### DIFF
--- a/asobi-fe/asobi-project-fe/src/app/page/schedule/schedule-page.component.html
+++ b/asobi-fe/asobi-project-fe/src/app/page/schedule/schedule-page.component.html
@@ -1,1 +1,6 @@
-<app-schedule-layout [tasks]="tasks()" (create)="onCreate($event)"></app-schedule-layout>
+<app-schedule-layout
+  [tasks]="tasks()"
+  [formVisible]="isFormVisible()"
+  (openForm)="openForm()"
+  (closeForm)="closeForm()"
+  (create)="onCreate($event)"></app-schedule-layout>

--- a/asobi-fe/asobi-project-fe/src/app/page/schedule/schedule-page.component.ts
+++ b/asobi-fe/asobi-project-fe/src/app/page/schedule/schedule-page.component.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectionStrategy, Component, OnInit, inject } from '@angular/core';
+import { ChangeDetectionStrategy, Component, OnInit, inject, signal } from '@angular/core';
 import { ScheduleLayoutComponent } from '../../view/layouts/schedule-layout/schedule-layout.component';
 import { ScheduleService } from '../../domain/service/impl/schedule.service.impl';
 import { ScheduleState } from '../../domain/state/local/schedule.state';
@@ -15,12 +15,22 @@ export class SchedulePageComponent implements OnInit {
   #service = inject(ScheduleService);
   #state = inject(ScheduleState);
   protected tasks = this.#state.tasks;
+  protected isFormVisible = signal(false);
 
   ngOnInit(): void {
     this.#service.load();
   }
 
+  openForm(): void {
+    this.isFormVisible.set(true);
+  }
+
+  closeForm(): void {
+    this.isFormVisible.set(false);
+  }
+
   onCreate(task: Task): void {
     this.#service.add(task);
+    this.closeForm();
   }
 }

--- a/asobi-fe/asobi-project-fe/src/app/view/layouts/schedule-layout/schedule-layout.component.html
+++ b/asobi-fe/asobi-project-fe/src/app/view/layouts/schedule-layout/schedule-layout.component.html
@@ -1,4 +1,17 @@
 <div class="layout">
-  <app-task-form (save)="create.emit($event)"></app-task-form>
+  <div class="toolbar">
+    <button (click)="openForm.emit()">タスクを追加</button>
+  </div>
   <app-gantt-chart [tasks]="tasks"></app-gantt-chart>
+  @if (formVisible) {
+    <div class="task-dialog" (click)="closeForm.emit()">
+      <div class="dialog" (click)="$event.stopPropagation()">
+        <h2>タスク追加</h2>
+        <app-task-form (save)="create.emit($event); closeForm.emit()"></app-task-form>
+        <div class="actions">
+          <button class="close" (click)="closeForm.emit()">閉じる</button>
+        </div>
+      </div>
+    </div>
+  }
 </div>

--- a/asobi-fe/asobi-project-fe/src/app/view/layouts/schedule-layout/schedule-layout.component.scss
+++ b/asobi-fe/asobi-project-fe/src/app/view/layouts/schedule-layout/schedule-layout.component.scss
@@ -1,5 +1,32 @@
 .layout {
+  padding: 1rem;
+}
+
+.toolbar {
+  text-align: right;
+  margin-bottom: 1rem;
+}
+
+.task-dialog {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.4);
   display: flex;
-  gap: 2rem;
-  align-items: flex-start;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+}
+
+.task-dialog .dialog {
+  background: #fff;
+  padding: 1.5rem;
+  border-radius: 8px;
+  width: 360px;
+  max-width: 90%;
+  box-shadow: 0 2px 10px rgba(0, 0, 0, 0.2);
+}
+
+.task-dialog .actions {
+  text-align: right;
+  margin-top: 1rem;
 }

--- a/asobi-fe/asobi-project-fe/src/app/view/layouts/schedule-layout/schedule-layout.component.ts
+++ b/asobi-fe/asobi-project-fe/src/app/view/layouts/schedule-layout/schedule-layout.component.ts
@@ -13,5 +13,8 @@ import { TaskFormComponent } from '../../parts/task-form/task-form.component';
 })
 export class ScheduleLayoutComponent {
   @Input({ required: true }) tasks: Task[] = [];
+  @Input() formVisible = false;
   @Output() create = new EventEmitter<Task>();
+  @Output() openForm = new EventEmitter<void>();
+  @Output() closeForm = new EventEmitter<void>();
 }

--- a/asobi-fe/asobi-project-fe/src/app/view/parts/gantt-chart/gantt-chart.component.html
+++ b/asobi-fe/asobi-project-fe/src/app/view/parts/gantt-chart/gantt-chart.component.html
@@ -1,8 +1,43 @@
-<div class="gantt">
-  @for (task of tasks; track task.id) {
-    <div class="row">
-      <div class="label">{{ task.name }} ({{ task.assignee }})</div>
-      <div class="bar" [style.width.%]="task.progress"></div>
-    </div>
-  }
-</div>
+@if (tasks.length > 0) {
+  <div class="gantt-wrapper">
+    <table class="gantt-table">
+      <thead>
+        <tr>
+          <th rowspan="2" class="sticky type-col">タスク分類</th>
+          <th rowspan="2" class="sticky name-col">タスク名</th>
+          <th rowspan="2" class="sticky detail-col">タスク詳細</th>
+          <th rowspan="2" class="sticky assignee-col">担当者</th>
+          <th rowspan="2" class="sticky start-col">開始日</th>
+          <th rowspan="2" class="sticky end-col">終了日</th>
+          <th rowspan="2" class="sticky progress-col">進捗率</th>
+          @for (month of months; track month.label) {
+            <th [attr.colspan]="month.days">{{ month.label }}</th>
+          }
+        </tr>
+        <tr>
+          @for (date of dateRange; track $index) {
+            <th>{{ date | date:'dd' }}</th>
+          }
+        </tr>
+      </thead>
+      <tbody>
+        @for (task of tasks; track task.id) {
+          <tr>
+            <td class="sticky type-col">{{ task.type }}</td>
+            <td class="sticky name-col">{{ task.name }}</td>
+            <td class="sticky detail-col">{{ task.detail }}</td>
+            <td class="sticky assignee-col">{{ task.assignee }}</td>
+            <td class="sticky start-col">{{ task.start | date:'yyyy-MM-dd' }}</td>
+            <td class="sticky end-col">{{ task.end | date:'yyyy-MM-dd' }}</td>
+            <td class="sticky progress-col">{{ task.progress }}%</td>
+            @for (date of dateRange; track $index) {
+              <td class="day" [class.progress]="isProgress(task, date)" [class.planned]="isPlanned(task, date)"></td>
+            }
+          </tr>
+        }
+      </tbody>
+    </table>
+  </div>
+} @else {
+  <p>タスクがありません。</p>
+}

--- a/asobi-fe/asobi-project-fe/src/app/view/parts/gantt-chart/gantt-chart.component.scss
+++ b/asobi-fe/asobi-project-fe/src/app/view/parts/gantt-chart/gantt-chart.component.scss
@@ -1,16 +1,58 @@
-.gantt {
+.gantt-wrapper {
+  overflow-x: auto;
+  background: #fff;
+  border: 1px solid #ddd;
+  border-radius: 4px;
+}
+
+.gantt-table {
+  border-collapse: collapse;
   width: 100%;
+  min-width: 800px;
+  font-size: 0.875rem;
 }
-.row {
-  display: flex;
-  align-items: center;
-  margin-bottom: 0.5rem;
+
+th,
+td {
+  border: 1px solid #e0e0e0;
+  padding: 4px;
+  text-align: center;
+  white-space: nowrap;
 }
-.label {
-  width: 150px;
+
+thead th {
+  position: sticky;
+  top: 0;
+  background: #f5f5f5;
+  z-index: 2;
 }
-.bar {
-  height: 20px;
-  background-color: #3f51b5;
-  transition: width 0.3s;
+
+.sticky {
+  position: sticky;
+  left: 0;
+  background: #fff;
+  z-index: 1;
 }
+
+.type-col { left: 0; min-width: 100px; }
+.name-col { left: 100px; min-width: 120px; }
+.detail-col { left: 220px; min-width: 180px; }
+.assignee-col { left: 400px; min-width: 80px; }
+.start-col { left: 480px; min-width: 110px; }
+.end-col { left: 590px; min-width: 110px; }
+.progress-col { left: 700px; min-width: 80px; }
+
+.day {
+  width: 24px;
+  height: 24px;
+  padding: 0;
+}
+
+.day.progress {
+  background-color: #4caf50;
+}
+
+.day.planned {
+  background-color: #ffcc80;
+}
+

--- a/asobi-fe/asobi-project-fe/src/app/view/parts/gantt-chart/gantt-chart.component.ts
+++ b/asobi-fe/asobi-project-fe/src/app/view/parts/gantt-chart/gantt-chart.component.ts
@@ -1,13 +1,76 @@
 import { ChangeDetectionStrategy, Component, Input } from '@angular/core';
+import { DatePipe } from '@angular/common';
 import { Task } from '../../../domain/model/task';
 
 @Component({
   selector: 'app-gantt-chart',
   standalone: true,
+  imports: [DatePipe],
   changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: './gantt-chart.component.html',
   styleUrl: './gantt-chart.component.scss'
 })
 export class GanttChartComponent {
   @Input({ required: true }) tasks: Task[] = [];
+
+  get dateRange(): Date[] {
+    if (this.tasks.length === 0) {
+      return [];
+    }
+    const start = new Date(Math.min(...this.tasks.map(t => t.start.getTime())));
+    const end = new Date(Math.max(...this.tasks.map(t => t.end.getTime())));
+    const dates: Date[] = [];
+    for (let d = new Date(start); d <= end; d.setDate(d.getDate() + 1)) {
+      dates.push(new Date(d));
+    }
+    return dates;
+  }
+
+  get months(): { label: string; days: number }[] {
+    const result: { label: string; days: number }[] = [];
+    this.dateRange.forEach(d => {
+      const label = `${d.getFullYear()}-${(d.getMonth() + 1).toString().padStart(2, '0')}`;
+      const last = result[result.length - 1];
+      if (last && last.label === label) {
+        last.days++;
+      } else {
+        result.push({ label, days: 1 });
+      }
+    });
+    return result;
+  }
+
+  isProgress(task: Task, date: Date): boolean {
+    const start = new Date(task.start);
+    const end = new Date(task.end);
+    if (date < start || date > end) {
+      return false;
+    }
+    const total = this.diffDays(start, end) + 1;
+    const progressDays = Math.round(total * (task.progress / 100));
+    const progressEnd = this.addDays(start, progressDays - 1);
+    return date <= progressEnd;
+  }
+
+  isPlanned(task: Task, date: Date): boolean {
+    const start = new Date(task.start);
+    const end = new Date(task.end);
+    if (date < start || date > end) {
+      return false;
+    }
+    const total = this.diffDays(start, end) + 1;
+    const progressDays = Math.round(total * (task.progress / 100));
+    const progressEnd = this.addDays(start, progressDays - 1);
+    return date > progressEnd && date <= end;
+  }
+
+  private diffDays(a: Date, b: Date): number {
+    return Math.floor((b.getTime() - a.getTime()) / (1000 * 60 * 60 * 24));
+  }
+
+  private addDays(date: Date, days: number): Date {
+    const result = new Date(date);
+    result.setDate(result.getDate() + days);
+    return result;
+  }
 }

--- a/asobi-fe/asobi-project-fe/src/app/view/parts/task-form/task-form.component.html
+++ b/asobi-fe/asobi-project-fe/src/app/view/parts/task-form/task-form.component.html
@@ -1,31 +1,33 @@
 <form (ngSubmit)="submit()" #f="ngForm">
-  <div>
-    <label>分類</label>
-    <input name="type" [(ngModel)]="task.type" />
+  <div class="field">
+    <label for="type">分類</label>
+    <input id="type" name="type" [(ngModel)]="task.type" />
   </div>
-  <div>
-    <label>タスク名</label>
-    <input name="name" [(ngModel)]="task.name" required />
+  <div class="field">
+    <label for="name">タスク名</label>
+    <input id="name" name="name" [(ngModel)]="task.name" required />
   </div>
-  <div>
-    <label>詳細</label>
-    <textarea name="detail" [(ngModel)]="task.detail"></textarea>
+  <div class="field">
+    <label for="detail">詳細</label>
+    <textarea id="detail" name="detail" [(ngModel)]="task.detail"></textarea>
   </div>
-  <div>
-    <label>担当者</label>
-    <input name="assignee" [(ngModel)]="task.assignee" />
+  <div class="field">
+    <label for="assignee">担当者</label>
+    <input id="assignee" name="assignee" [(ngModel)]="task.assignee" />
   </div>
-  <div>
-    <label>開始日</label>
-    <input type="date" name="start" [(ngModel)]="task.start" />
+  <div class="field">
+    <label for="start">開始日</label>
+    <input id="start" type="date" name="start" [(ngModel)]="task.start" />
   </div>
-  <div>
-    <label>終了日</label>
-    <input type="date" name="end" [(ngModel)]="task.end" />
+  <div class="field">
+    <label for="end">終了日</label>
+    <input id="end" type="date" name="end" [(ngModel)]="task.end" />
   </div>
-  <div>
-    <label>進捗(%)</label>
-    <input type="number" name="progress" [(ngModel)]="task.progress" min="0" max="100" />
+  <div class="field">
+    <label for="progress">進捗(%)</label>
+    <input id="progress" type="number" name="progress" [(ngModel)]="task.progress" min="0" max="100" />
   </div>
-  <button type="submit">登録</button>
+  <div class="actions">
+    <button type="submit" [disabled]="f.invalid">登録</button>
+  </div>
 </form>

--- a/asobi-fe/asobi-project-fe/src/app/view/parts/task-form/task-form.component.scss
+++ b/asobi-fe/asobi-project-fe/src/app/view/parts/task-form/task-form.component.scss
@@ -1,9 +1,28 @@
 form {
   display: flex;
   flex-direction: column;
-  gap: 0.5rem;
+  gap: 1rem;
+  width: 100%;
 }
+
+.field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
 label {
-  display: block;
   font-weight: bold;
+}
+
+input,
+textarea {
+  padding: 0.5rem;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+  font-size: 0.875rem;
+}
+
+.actions {
+  text-align: right;
 }

--- a/asobi-fe/asobi-project-fe/src/styles.scss
+++ b/asobi-fe/asobi-project-fe/src/styles.scss
@@ -1,1 +1,21 @@
 /* You can add global styles to this file, and also import other style files */
+
+body {
+  margin: 0;
+  font-family: Arial, Helvetica, sans-serif;
+  background-color: #f0f2f5;
+  color: #333;
+}
+
+button {
+  padding: 0.5rem 1rem;
+  border: none;
+  border-radius: 4px;
+  background-color: #1976d2;
+  color: #fff;
+  cursor: pointer;
+}
+
+button:hover {
+  background-color: #1565c0;
+}


### PR DESCRIPTION
## 概要
- タスク追加フォームをダイアログ化し、モダンなレイアウトに変更
- ガントチャートを表形式で再実装し、横スクロール可能なタイムラインを追加
- 全体的なスタイルを調整してスマートなデザインに刷新

## テスト
- `npm test -- --watch=false` を実行 → Chrome の不足により失敗 (`snap install chromium` が必要)


------
https://chatgpt.com/codex/tasks/task_e_6899fc535e10833198d8802a4b5b4a48