### PR TITLE
ガントチャートの表示改善

### DIFF
--- a/asobi-fe/asobi-project-fe/src/app/view/parts/gantt-chart/gantt-chart.component.html
+++ b/asobi-fe/asobi-project-fe/src/app/view/parts/gantt-chart/gantt-chart.component.html
@@ -1,43 +1,39 @@
-@if (tasks.length > 0) {
-  <div class="gantt-wrapper">
-    <table class="gantt-table">
-      <thead>
-        <tr>
-          <th rowspan="2" class="sticky type-col">タスク分類</th>
-          <th rowspan="2" class="sticky name-col">タスク名</th>
-          <th rowspan="2" class="sticky detail-col">タスク詳細</th>
-          <th rowspan="2" class="sticky assignee-col">担当者</th>
-          <th rowspan="2" class="sticky start-col">開始日</th>
-          <th rowspan="2" class="sticky end-col">終了日</th>
-          <th rowspan="2" class="sticky progress-col">進捗率</th>
-          @for (month of months; track month.label) {
-            <th [attr.colspan]="month.days">{{ month.label }}</th>
-          }
-        </tr>
-        <tr>
-          @for (date of dateRange; track $index) {
-            <th>{{ date | date:'dd' }}</th>
-          }
-        </tr>
-      </thead>
-      <tbody>
-        @for (task of tasks; track task.id) {
-          <tr>
-            <td class="sticky type-col">{{ task.type }}</td>
-            <td class="sticky name-col">{{ task.name }}</td>
-            <td class="sticky detail-col">{{ task.detail }}</td>
-            <td class="sticky assignee-col">{{ task.assignee }}</td>
-            <td class="sticky start-col">{{ task.start | date:'yyyy-MM-dd' }}</td>
-            <td class="sticky end-col">{{ task.end | date:'yyyy-MM-dd' }}</td>
-            <td class="sticky progress-col">{{ task.progress }}%</td>
-            @for (date of dateRange; track $index) {
-              <td class="day" [class.progress]="isProgress(task, date)" [class.planned]="isPlanned(task, date)"></td>
-            }
-          </tr>
+<div class="gantt-wrapper" #ganttWrapper>
+  <table class="gantt-table">
+    <thead>
+      <tr>
+        <th rowspan="2" class="sticky type-col">タスク分類</th>
+        <th rowspan="2" class="sticky name-col">タスク名</th>
+        <th rowspan="2" class="sticky detail-col">タスク詳細</th>
+        <th rowspan="2" class="sticky assignee-col">担当者</th>
+        <th rowspan="2" class="sticky start-col">開始日</th>
+        <th rowspan="2" class="sticky end-col">終了日</th>
+        <th rowspan="2" class="sticky progress-col">進捗率</th>
+        @for (month of months; track month.label) {
+          <th [attr.colspan]="month.days">{{ month.label }}</th>
         }
-      </tbody>
-    </table>
-  </div>
-} @else {
-  <p>タスクがありません。</p>
-}
+      </tr>
+      <tr>
+        @for (date of dateRange; track $index) {
+          <th>{{ date | date:'dd' }}</th>
+        }
+      </tr>
+    </thead>
+    <tbody>
+      @for (task of tasks; track task.id) {
+        <tr>
+          <td class="sticky type-col">{{ task.type }}</td>
+          <td class="sticky name-col">{{ task.name }}</td>
+          <td class="sticky detail-col">{{ task.detail }}</td>
+          <td class="sticky assignee-col">{{ task.assignee }}</td>
+          <td class="sticky start-col">{{ task.start | date:'yyyy-MM-dd' }}</td>
+          <td class="sticky end-col">{{ task.end | date:'yyyy-MM-dd' }}</td>
+          <td class="sticky progress-col">{{ task.progress }}%</td>
+          @for (date of dateRange; track $index) {
+            <td class="day" [class.progress]="isProgress(task, date)" [class.planned]="isPlanned(task, date)"></td>
+          }
+        </tr>
+      }
+    </tbody>
+  </table>
+</div>

--- a/asobi-fe/asobi-project-fe/src/app/view/parts/gantt-chart/gantt-chart.component.scss
+++ b/asobi-fe/asobi-project-fe/src/app/view/parts/gantt-chart/gantt-chart.component.scss
@@ -7,8 +7,7 @@
 
 .gantt-table {
   border-collapse: collapse;
-  width: 100%;
-  min-width: 800px;
+  width: calc(780px + 60vw);
   font-size: 0.875rem;
 }
 


### PR DESCRIPTION
## Summary
- ガントチャートを常時表示し、初期表示を今日の日付にスクロール
- 日付範囲を今日から30日以上表示し、横スクロールで期間調整可能に
- タイムライン領域を画面幅の60%確保

## Testing
- `npm test -- --watch=false --browsers=ChromeHeadless` *(Chrome 未インストールのため失敗)*

------
https://chatgpt.com/codex/tasks/task_e_689a048cc8b4833197886d3eda91f76e