### PR TITLE
ガントチャートのレイアウトとデザイン改善

### DIFF
--- a/asobi-fe/asobi-project-fe/src/app/view/parts/gantt-chart/gantt-chart.component.html
+++ b/asobi-fe/asobi-project-fe/src/app/view/parts/gantt-chart/gantt-chart.component.html
@@ -1,39 +1,75 @@
-<div class="gantt-wrapper" #ganttWrapper>
-  <table class="gantt-table">
-    <thead>
-      <tr>
-        <th rowspan="2" class="sticky type-col">タスク分類</th>
-        <th rowspan="2" class="sticky name-col">タスク名</th>
-        <th rowspan="2" class="sticky detail-col">タスク詳細</th>
-        <th rowspan="2" class="sticky assignee-col">担当者</th>
-        <th rowspan="2" class="sticky start-col">開始日</th>
-        <th rowspan="2" class="sticky end-col">終了日</th>
-        <th rowspan="2" class="sticky progress-col">進捗率</th>
-        @for (month of months; track month.label) {
-          <th [attr.colspan]="month.days">{{ month.label }}</th>
-        }
-      </tr>
-      <tr>
-        @for (date of dateRange; track $index) {
-          <th>{{ date | date:'dd' }}</th>
-        }
-      </tr>
-    </thead>
-    <tbody>
-      @for (task of tasks; track task.id) {
+<div class="gantt-container">
+  <div class="task-area">
+    <table class="task-table">
+      <thead>
         <tr>
-          <td class="sticky type-col">{{ task.type }}</td>
-          <td class="sticky name-col">{{ task.name }}</td>
-          <td class="sticky detail-col">{{ task.detail }}</td>
-          <td class="sticky assignee-col">{{ task.assignee }}</td>
-          <td class="sticky start-col">{{ task.start | date:'yyyy-MM-dd' }}</td>
-          <td class="sticky end-col">{{ task.end | date:'yyyy-MM-dd' }}</td>
-          <td class="sticky progress-col">{{ task.progress }}%</td>
-          @for (date of dateRange; track $index) {
-            <td class="day" [class.progress]="isProgress(task, date)" [class.planned]="isPlanned(task, date)"></td>
+          <th class="type-col">タスク分類</th>
+          <th class="name-col">タスク名</th>
+          <th class="detail-col">タスク詳細</th>
+          <th class="assignee-col">担当者</th>
+          <th class="start-col">開始日</th>
+          <th class="end-col">終了日</th>
+          <th class="progress-col">進捗率</th>
+        </tr>
+      </thead>
+      <tbody>
+        @if (tasks.length > 0) {
+          @for (task of tasks; track task.id) {
+            <tr>
+              <td class="type-col">{{ task.type }}</td>
+              <td class="name-col">{{ task.name }}</td>
+              <td class="detail-col">{{ task.detail }}</td>
+              <td class="assignee-col">{{ task.assignee }}</td>
+              <td class="start-col">{{ task.start | date:'yyyy-MM-dd' }}</td>
+              <td class="end-col">{{ task.end | date:'yyyy-MM-dd' }}</td>
+              <td class="progress-col">{{ task.progress }}%</td>
+            </tr>
+          }
+        } @else {
+          <tr>
+            <td class="type-col"></td>
+            <td class="name-col"></td>
+            <td class="detail-col"></td>
+            <td class="assignee-col"></td>
+            <td class="start-col"></td>
+            <td class="end-col"></td>
+            <td class="progress-col"></td>
+          </tr>
+        }
+      </tbody>
+    </table>
+  </div>
+  <div class="chart-area" #chartArea>
+    <table class="chart-table">
+      <thead>
+        <tr>
+          @for (month of months; track month.label) {
+            <th [attr.colspan]="month.days">{{ month.label }}</th>
           }
         </tr>
-      }
-    </tbody>
-  </table>
+        <tr>
+          @for (date of dateRange; track $index) {
+            <th class="date-col">{{ date | date:'dd' }}</th>
+          }
+        </tr>
+      </thead>
+      <tbody>
+        @if (tasks.length > 0) {
+          @for (task of tasks; track task.id) {
+            <tr>
+              @for (date of dateRange; track $index) {
+                <td class="day" [class.progress]="isProgress(task, date)" [class.planned]="isPlanned(task, date)"></td>
+              }
+            </tr>
+          }
+        } @else {
+          <tr>
+            @for (date of dateRange; track $index) {
+              <td class="day"></td>
+            }
+          </tr>
+        }
+      </tbody>
+    </table>
+  </div>
 </div>

--- a/asobi-fe/asobi-project-fe/src/app/view/parts/gantt-chart/gantt-chart.component.scss
+++ b/asobi-fe/asobi-project-fe/src/app/view/parts/gantt-chart/gantt-chart.component.scss
@@ -1,14 +1,26 @@
-.gantt-wrapper {
-  overflow-x: auto;
-  background: #fff;
+.gantt-container {
+  display: flex;
   border: 1px solid #ddd;
-  border-radius: 4px;
+  border-radius: 8px;
+  background: #fafafa;
 }
 
-.gantt-table {
+.task-area {
+  overflow: hidden;
+}
+
+.chart-area {
+  overflow-x: auto;
+}
+
+.task-table,
+.chart-table {
   border-collapse: collapse;
-  width: calc(780px + 60vw);
   font-size: 0.875rem;
+}
+
+.task-table {
+  width: 780px;
 }
 
 th,
@@ -19,39 +31,39 @@ td {
   white-space: nowrap;
 }
 
-thead th {
+.task-table thead th,
+.chart-table thead th {
   position: sticky;
   top: 0;
-  background: #f5f5f5;
-  z-index: 2;
-}
-
-.sticky {
-  position: sticky;
-  left: 0;
-  background: #fff;
+  background: #e3f2fd;
   z-index: 1;
 }
 
-.type-col { left: 0; min-width: 100px; }
-.name-col { left: 100px; min-width: 120px; }
-.detail-col { left: 220px; min-width: 180px; }
-.assignee-col { left: 400px; min-width: 80px; }
-.start-col { left: 480px; min-width: 110px; }
-.end-col { left: 590px; min-width: 110px; }
-.progress-col { left: 700px; min-width: 80px; }
+.type-col { min-width: 100px; }
+.name-col { min-width: 120px; }
+.detail-col { min-width: 180px; }
+.assignee-col { min-width: 80px; }
+.start-col { min-width: 110px; }
+.end-col { min-width: 110px; }
+.progress-col { min-width: 80px; }
 
 .day {
-  width: 24px;
+  width: 36px;
   height: 24px;
   padding: 0;
 }
 
 .day.progress {
-  background-color: #4caf50;
+  background-color: #42a5f5;
 }
 
 .day.planned {
-  background-color: #ffcc80;
+  background-color: #90caf9;
 }
+
+.task-table tbody tr:nth-child(even),
+.chart-table tbody tr:nth-child(even) {
+  background: #f9f9f9;
+}
+
 

--- a/asobi-fe/asobi-project-fe/src/app/view/parts/gantt-chart/gantt-chart.component.ts
+++ b/asobi-fe/asobi-project-fe/src/app/view/parts/gantt-chart/gantt-chart.component.ts
@@ -20,7 +20,7 @@ import { Task } from '../../../domain/model/task';
 })
 export class GanttChartComponent implements AfterViewInit, OnChanges {
   @Input({ required: true }) tasks: Task[] = [];
-  @ViewChild('ganttWrapper') private ganttWrapper?: ElementRef<HTMLDivElement>;
+  @ViewChild('chartArea') private chartArea?: ElementRef<HTMLDivElement>;
 
   private readonly today: Date = new Date();
 
@@ -81,15 +81,15 @@ export class GanttChartComponent implements AfterViewInit, OnChanges {
   }
 
   private scrollToToday(): void {
-    if (!this.ganttWrapper) {
+    if (!this.chartArea) {
       return;
     }
     const index = this.dateRange.findIndex(d => this.isSameDay(d, this.today));
     if (index < 0) {
       return;
     }
-    const dayWidth = 26; // cell width + border
-    this.ganttWrapper.nativeElement.scrollLeft = index * dayWidth;
+    const dayWidth = 38; // cell width + border
+    this.chartArea.nativeElement.scrollLeft = index * dayWidth;
   }
 
   private isSameDay(a: Date, b: Date): boolean {


### PR DESCRIPTION
## 概要
- タスク未登録時も空の表を表示
- 月日部分のみ横スクロールできるようレイアウトを分割
- 日付セル幅拡大と配色の刷新

## テスト
- `npm test -- --watch=false --browsers=ChromeHeadless`（Chrome が snap 依存のため起動失敗）
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689a0942fc888331b702f73a6b8afaa1