### PR TITLE
ヘッダー追加とガントチャート表示改善

### DIFF
--- a/asobi-fe/asobi-project-fe/src/app/view/layouts/schedule-layout/schedule-layout.component.html
+++ b/asobi-fe/asobi-project-fe/src/app/view/layouts/schedule-layout/schedule-layout.component.html
@@ -1,17 +1,20 @@
 <div class="layout">
-  <div class="toolbar">
-    <button (click)="openForm.emit()">タスクを追加</button>
-  </div>
-  <app-gantt-chart [tasks]="tasks"></app-gantt-chart>
-  @if (formVisible) {
-    <div class="task-dialog" (click)="closeForm.emit()">
-      <div class="dialog" (click)="$event.stopPropagation()">
-        <h2>タスク追加</h2>
-        <app-task-form (save)="create.emit($event); closeForm.emit()"></app-task-form>
-        <div class="actions">
-          <button class="close" (click)="closeForm.emit()">閉じる</button>
+  <app-header></app-header>
+  <div class="content">
+    <div class="toolbar">
+      <button (click)="openForm.emit()">タスクを追加</button>
+    </div>
+    <app-gantt-chart [tasks]="tasks"></app-gantt-chart>
+    @if (formVisible) {
+      <div class="task-dialog" (click)="closeForm.emit()">
+        <div class="dialog" (click)="$event.stopPropagation()">
+          <h2>タスク追加</h2>
+          <app-task-form (save)="create.emit($event); closeForm.emit()"></app-task-form>
+          <div class="actions">
+            <button class="close" (click)="closeForm.emit()">閉じる</button>
+          </div>
         </div>
       </div>
-    </div>
-  }
+    }
+  </div>
 </div>

--- a/asobi-fe/asobi-project-fe/src/app/view/layouts/schedule-layout/schedule-layout.component.scss
+++ b/asobi-fe/asobi-project-fe/src/app/view/layouts/schedule-layout/schedule-layout.component.scss
@@ -1,10 +1,24 @@
+
 .layout {
+  display: flex;
+  flex-direction: column;
+  height: 100vh;
+}
+
+.content {
   padding: 1rem;
+  flex: 1;
+  display: flex;
+  flex-direction: column;
 }
 
 .toolbar {
   text-align: right;
   margin-bottom: 1rem;
+}
+
+app-gantt-chart {
+  flex: 1;
 }
 
 .task-dialog {

--- a/asobi-fe/asobi-project-fe/src/app/view/layouts/schedule-layout/schedule-layout.component.ts
+++ b/asobi-fe/asobi-project-fe/src/app/view/layouts/schedule-layout/schedule-layout.component.ts
@@ -2,11 +2,12 @@ import { ChangeDetectionStrategy, Component, EventEmitter, Input, Output } from 
 import { Task } from '../../../domain/model/task';
 import { GanttChartComponent } from '../../parts/gantt-chart/gantt-chart.component';
 import { TaskFormComponent } from '../../parts/task-form/task-form.component';
+import { HeaderComponent } from '../../parts/header/header.component';
 
 @Component({
   selector: 'app-schedule-layout',
   standalone: true,
-  imports: [GanttChartComponent, TaskFormComponent],
+  imports: [HeaderComponent, GanttChartComponent, TaskFormComponent],
   changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: './schedule-layout.component.html',
   styleUrl: './schedule-layout.component.scss'

--- a/asobi-fe/asobi-project-fe/src/app/view/parts/gantt-chart/gantt-chart.component.scss
+++ b/asobi-fe/asobi-project-fe/src/app/view/parts/gantt-chart/gantt-chart.component.scss
@@ -1,26 +1,33 @@
 .gantt-container {
   display: flex;
+  width: 100%;
   border: 1px solid #ddd;
   border-radius: 8px;
   background: #fafafa;
 }
 
 .task-area {
-  overflow: hidden;
+  flex: 0 0 780px;
+  overflow-x: hidden;
+  overflow-y: auto;
+  min-height: 300px;
 }
 
 .chart-area {
-  overflow-x: auto;
+  flex: 1;
+  overflow: auto;
+  min-height: 300px;
 }
 
 .task-table,
 .chart-table {
   border-collapse: collapse;
   font-size: 0.875rem;
+  table-layout: fixed;
 }
 
 .task-table {
-  width: 780px;
+  width: 100%;
 }
 
 th,

--- a/asobi-fe/asobi-project-fe/src/app/view/parts/header/header.component.html
+++ b/asobi-fe/asobi-project-fe/src/app/view/parts/header/header.component.html
@@ -1,0 +1,10 @@
+<header class="header">
+  <div class="title">
+    <span class="logo" aria-hidden="true">🎮</span>
+    <span>asobi</span>
+  </div>
+  <button class="logout" (click)="logout.emit()">
+    <span class="logo" aria-hidden="true">🚪</span>
+    ログアウト
+  </button>
+</header>

--- a/asobi-fe/asobi-project-fe/src/app/view/parts/header/header.component.scss
+++ b/asobi-fe/asobi-project-fe/src/app/view/parts/header/header.component.scss
@@ -1,0 +1,28 @@
+.header {
+  background: #000;
+  color: #fff;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 0.5rem 1rem;
+}
+
+.title,
+.logout {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.logout {
+  background: transparent;
+  border: 1px solid #fff;
+  color: #fff;
+  padding: 0.25rem 0.75rem;
+  border-radius: 4px;
+  cursor: pointer;
+}
+
+.logo {
+  font-size: 1.2rem;
+}

--- a/asobi-fe/asobi-project-fe/src/app/view/parts/header/header.component.ts
+++ b/asobi-fe/asobi-project-fe/src/app/view/parts/header/header.component.ts
@@ -1,0 +1,12 @@
+import { ChangeDetectionStrategy, Component, EventEmitter, Output } from '@angular/core';
+
+@Component({
+  selector: 'app-header',
+  standalone: true,
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  templateUrl: './header.component.html',
+  styleUrl: './header.component.scss'
+})
+export class HeaderComponent {
+  @Output() logout = new EventEmitter<void>();
+}


### PR DESCRIPTION
## 概要
- 画面上部に黒背景・白文字のヘッダーを追加し、左側に画面名 asobi とロゴ、右側にログアウトボタンを配置
- タスクが無い場合でもガントチャートの表領域が確保されるようにし、日付部分を横スクロール可能に調整
- 進捗率欄が日付欄に重ならないようタスク情報エリアのレイアウトを固定幅化

## テスト
- `npm test` (Chrome 未インストールにより失敗)

------
https://chatgpt.com/codex/tasks/task_e_689a0cede2708331af8a829eabb25c42