### PR TITLE
Ganttチャートの空行とスクロール改善

### DIFF
--- a/asobi-fe/asobi-project-fe/src/app/view/parts/gantt-chart/gantt-chart.component.html
+++ b/asobi-fe/asobi-project-fe/src/app/view/parts/gantt-chart/gantt-chart.component.html
@@ -1,5 +1,5 @@
 <div class="gantt-container">
-  <div class="task-area">
+  <div class="task-area" #taskArea>
     <table class="task-table">
       <thead>
         <tr>
@@ -26,15 +26,17 @@
             </tr>
           }
         } @else {
-          <tr>
-            <td class="type-col"></td>
-            <td class="name-col"></td>
-            <td class="detail-col"></td>
-            <td class="assignee-col"></td>
-            <td class="start-col"></td>
-            <td class="end-col"></td>
-            <td class="progress-col"></td>
-          </tr>
+          @for (row of emptyRows; track $index) {
+            <tr>
+              <td class="type-col"></td>
+              <td class="name-col"></td>
+              <td class="detail-col"></td>
+              <td class="assignee-col"></td>
+              <td class="start-col"></td>
+              <td class="end-col"></td>
+              <td class="progress-col"></td>
+            </tr>
+          }
         }
       </tbody>
     </table>
@@ -63,11 +65,13 @@
             </tr>
           }
         } @else {
-          <tr>
-            @for (date of dateRange; track $index) {
-              <td class="day"></td>
-            }
-          </tr>
+          @for (row of emptyRows; track $index) {
+            <tr>
+              @for (date of dateRange; track $index) {
+                <td class="day"></td>
+              }
+            </tr>
+          }
         }
       </tbody>
     </table>

--- a/asobi-fe/asobi-project-fe/src/app/view/parts/gantt-chart/gantt-chart.component.scss
+++ b/asobi-fe/asobi-project-fe/src/app/view/parts/gantt-chart/gantt-chart.component.scss
@@ -1,6 +1,12 @@
+:host {
+  display: block;
+  height: 100%;
+}
+
 .gantt-container {
   display: flex;
   width: 100%;
+  height: 100%;
   border: 1px solid #ddd;
   border-radius: 8px;
   background: #fafafa;
@@ -9,13 +15,15 @@
 .task-area {
   flex: 0 0 780px;
   overflow-x: hidden;
-  overflow-y: auto;
+  overflow-y: hidden;
+  height: 100%;
   min-height: 300px;
 }
 
 .chart-area {
   flex: 1;
   overflow: auto;
+  height: 100%;
   min-height: 300px;
 }
 

--- a/asobi-fe/asobi-project-fe/src/app/view/parts/gantt-chart/gantt-chart.component.ts
+++ b/asobi-fe/asobi-project-fe/src/app/view/parts/gantt-chart/gantt-chart.component.ts
@@ -21,6 +21,9 @@ import { Task } from '../../../domain/model/task';
 export class GanttChartComponent implements AfterViewInit, OnChanges {
   @Input({ required: true }) tasks: Task[] = [];
   @ViewChild('chartArea') private chartArea?: ElementRef<HTMLDivElement>;
+  @ViewChild('taskArea') private taskArea?: ElementRef<HTMLDivElement>;
+
+  protected readonly emptyRows = Array.from({ length: 100 });
 
   private readonly today: Date = new Date();
 
@@ -29,7 +32,7 @@ export class GanttChartComponent implements AfterViewInit, OnChanges {
     start.setHours(0, 0, 0, 0);
 
     let startTime = start.getTime();
-    let endTime = this.addDays(start, 30).getTime();
+    let endTime = this.addDays(start, 365).getTime();
 
     if (this.tasks.length > 0) {
       const taskStart = Math.min(...this.tasks.map(t => t.start.getTime()));
@@ -74,6 +77,7 @@ export class GanttChartComponent implements AfterViewInit, OnChanges {
 
   ngAfterViewInit(): void {
     this.scrollToToday();
+    this.setupScrollSync();
   }
 
   ngOnChanges(): void {
@@ -90,6 +94,15 @@ export class GanttChartComponent implements AfterViewInit, OnChanges {
     }
     const dayWidth = 38; // cell width + border
     this.chartArea.nativeElement.scrollLeft = index * dayWidth;
+  }
+
+  private setupScrollSync(): void {
+    if (!this.chartArea || !this.taskArea) {
+      return;
+    }
+    this.chartArea.nativeElement.addEventListener('scroll', () => {
+      this.taskArea!.nativeElement.scrollTop = this.chartArea!.nativeElement.scrollTop;
+    });
   }
 
   private isSameDay(a: Date, b: Date): boolean {


### PR DESCRIPTION
## 概要
- タスクが無い場合でも100行の空行を表示
- ヘッダー固定のまま縦スクロール可能に
- 日付範囲を拡張し横スクロールで月を移動

## テスト
- `npm test -- --watch=false --browsers=ChromeHeadless` : ChromeHeadless のバイナリがなく失敗

------
https://chatgpt.com/codex/tasks/task_e_689a15a719b4833197ef7c79066aec68