### PR TITLE
feat: 画面高さにフィットするガントチャート

### DIFF
--- a/asobi-fe/asobi-project-fe/src/app/view/layouts/schedule-layout/schedule-layout.component.scss
+++ b/asobi-fe/asobi-project-fe/src/app/view/layouts/schedule-layout/schedule-layout.component.scss
@@ -6,15 +6,15 @@
 }
 
 .content {
-  padding: 1rem;
   flex: 1;
   display: flex;
   flex-direction: column;
+  overflow: hidden;
 }
 
 .toolbar {
   text-align: right;
-  margin-bottom: 1rem;
+  padding: 0.5rem 1rem;
 }
 
 app-gantt-chart {

--- a/asobi-fe/asobi-project-fe/src/app/view/parts/gantt-chart/gantt-chart.component.scss
+++ b/asobi-fe/asobi-project-fe/src/app/view/parts/gantt-chart/gantt-chart.component.scss
@@ -46,6 +46,21 @@ td {
   white-space: nowrap;
 }
 
+.task-table tbody tr,
+.chart-table tbody tr {
+  height: 24px;
+}
+
+.task-table tbody td {
+  padding: 0 4px;
+  height: 24px;
+  line-height: 24px;
+}
+
+.chart-table tbody td {
+  height: 24px;
+}
+
 .task-table thead th,
 .chart-table thead th {
   position: sticky;


### PR DESCRIPTION
## Summary
- タスク情報行と日付行の高さを統一
- スクロール端で日付範囲を自動拡張し無限スクロールに対応
- ヘッダーとツールバーを含めて画面全体に収まるレイアウト調整

## Testing
- `npm test` *(Chromeが見つからず失敗)*

------
https://chatgpt.com/codex/tasks/task_e_689a1ca1b1908331995a1aa69c1e6593