### PR TITLE
ガントチャートのスクロール改善とヘッダー調整

### DIFF
--- a/asobi-fe/asobi-project-fe/src/app/view/parts/gantt-chart/gantt-chart.component.scss
+++ b/asobi-fe/asobi-project-fe/src/app/view/parts/gantt-chart/gantt-chart.component.scss
@@ -15,9 +15,15 @@
 .task-area {
   flex: 0 0 780px;
   overflow-x: hidden;
-  overflow-y: hidden;
+  overflow-y: auto;
   height: 100%;
   min-height: 300px;
+  scrollbar-width: none;
+  -ms-overflow-style: none;
+}
+
+.task-area::-webkit-scrollbar {
+  display: none;
 }
 
 .chart-area {
@@ -67,6 +73,11 @@ td {
   top: 0;
   background: #e3f2fd;
   z-index: 1;
+}
+
+.task-table thead th {
+  height: 48px;
+  vertical-align: middle;
 }
 
 .type-col { min-width: 100px; }

--- a/asobi-fe/asobi-project-fe/src/app/view/parts/gantt-chart/gantt-chart.component.ts
+++ b/asobi-fe/asobi-project-fe/src/app/view/parts/gantt-chart/gantt-chart.component.ts
@@ -31,6 +31,7 @@ export class GanttChartComponent implements AfterViewInit, OnChanges {
   protected dateRange: Date[] = [];
   private rangeStart: Date;
   private rangeEnd: Date;
+  private isSyncing = false;
 
   constructor(private cdr: ChangeDetectorRef) {
     const start = new Date(this.today);
@@ -94,7 +95,13 @@ export class GanttChartComponent implements AfterViewInit, OnChanges {
     }
     const chartEl = this.chartArea.nativeElement;
     const taskEl = this.taskArea.nativeElement;
+
     chartEl.addEventListener('scroll', () => {
+      if (this.isSyncing) {
+        this.isSyncing = false;
+        return;
+      }
+      this.isSyncing = true;
       taskEl.scrollTop = chartEl.scrollTop;
 
       if (chartEl.scrollLeft + chartEl.clientWidth >= chartEl.scrollWidth - 100) {
@@ -104,6 +111,15 @@ export class GanttChartComponent implements AfterViewInit, OnChanges {
         this.extendLeft(365);
         chartEl.scrollLeft += chartEl.scrollWidth - prevWidth;
       }
+    });
+
+    taskEl.addEventListener('scroll', () => {
+      if (this.isSyncing) {
+        this.isSyncing = false;
+        return;
+      }
+      this.isSyncing = true;
+      chartEl.scrollTop = taskEl.scrollTop;
     });
   }
 


### PR DESCRIPTION
## Summary
- ガントチャートに縦スクロール同期機能を追加
- タスク情報ヘッダーを月日ヘッダーと同じ高さに調整

## Testing
- `npm test` (Chromeブラウザが見つからず失敗)


------
https://chatgpt.com/codex/tasks/task_e_689a273b697883318bcd9449be5cab97