### PR TITLE
ガントチャートの縦スクロール対応とヘッダー調整

### DIFF
--- a/asobi-fe/asobi-project-fe/src/app/view/layouts/schedule-layout/schedule-layout.component.scss
+++ b/asobi-fe/asobi-project-fe/src/app/view/layouts/schedule-layout/schedule-layout.component.scss
@@ -19,6 +19,7 @@
 
 app-gantt-chart {
   flex: 1;
+  min-height: 0;
 }
 
 .task-dialog {

--- a/asobi-fe/asobi-project-fe/src/app/view/parts/gantt-chart/gantt-chart.component.scss
+++ b/asobi-fe/asobi-project-fe/src/app/view/parts/gantt-chart/gantt-chart.component.scss
@@ -69,6 +69,27 @@ td {
   z-index: 1;
 }
 
+.task-table thead th {
+  height: 48px;
+  line-height: 48px;
+  padding: 0 4px;
+}
+
+.chart-table thead tr:first-child th {
+  top: 0;
+  height: 24px;
+  line-height: 24px;
+  padding: 0 4px;
+  z-index: 2;
+}
+
+.chart-table thead tr:nth-child(2) th {
+  top: 24px;
+  height: 24px;
+  line-height: 24px;
+  padding: 0 4px;
+}
+
 .type-col { min-width: 100px; }
 .name-col { min-width: 120px; }
 .detail-col { min-width: 180px; }


### PR DESCRIPTION
## 概要
- ガントチャートの表示領域を画面内に収め、縦スクロールでタスクを閲覧できるように変更
- ヘッダー高さを調整し、タスク情報ヘッダーと月・日付ヘッダーの高さを揃えつつスクロール時も固定

## テスト
- `npm test` を実行（Chrome が存在せず失敗）

------
https://chatgpt.com/codex/tasks/task_e_689a273b697883318bcd9449be5cab97