### PR TITLE
feat: フッターに現在日時を表示

### DIFF
--- a/asobi-fe/asobi-project-fe/src/app/domain/service/impl/clock.service.impl.ts
+++ b/asobi-fe/asobi-project-fe/src/app/domain/service/impl/clock.service.impl.ts
@@ -1,0 +1,20 @@
+import { Injectable, inject } from '@angular/core';
+import { ClockServiceInterface } from '../interface/clock.service';
+import { ClockState } from '../../state/global/clock.state';
+
+@Injectable({ providedIn: 'root' })
+export class ClockService implements ClockServiceInterface {
+  #state = inject(ClockState);
+
+  start(): void {
+    this.#update();
+    setInterval(() => this.#update(), 60000);
+  }
+
+  #update(): void {
+    const now = new Date();
+    const pad = (n: number) => n.toString().padStart(2, '0');
+    const formatted = `${now.getFullYear()}/${pad(now.getMonth() + 1)}/${pad(now.getDate())} ${pad(now.getHours())}:${pad(now.getMinutes())}`;
+    this.#state.setNow(formatted);
+  }
+}

--- a/asobi-fe/asobi-project-fe/src/app/domain/service/interface/clock.service.ts
+++ b/asobi-fe/asobi-project-fe/src/app/domain/service/interface/clock.service.ts
@@ -1,0 +1,3 @@
+export interface ClockServiceInterface {
+  start(): void;
+}

--- a/asobi-fe/asobi-project-fe/src/app/domain/state/global/clock.state.ts
+++ b/asobi-fe/asobi-project-fe/src/app/domain/state/global/clock.state.ts
@@ -1,0 +1,12 @@
+import { Injectable, signal } from '@angular/core';
+import { ClockStateInterface } from '../interface/clock-state';
+
+@Injectable({ providedIn: 'root' })
+export class ClockState implements ClockStateInterface {
+  #now = signal<string>('');
+  readonly now = this.#now.asReadonly();
+
+  setNow(now: string): void {
+    this.#now.set(now);
+  }
+}

--- a/asobi-fe/asobi-project-fe/src/app/domain/state/interface/clock-state.ts
+++ b/asobi-fe/asobi-project-fe/src/app/domain/state/interface/clock-state.ts
@@ -1,0 +1,6 @@
+import { Signal } from '@angular/core';
+
+export interface ClockStateInterface {
+  readonly now: Signal<string>;
+  setNow(now: string): void;
+}

--- a/asobi-fe/asobi-project-fe/src/app/page/schedule/schedule-page.component.html
+++ b/asobi-fe/asobi-project-fe/src/app/page/schedule/schedule-page.component.html
@@ -1,6 +1,7 @@
 <app-schedule-layout
   [tasks]="tasks()"
   [formVisible]="isFormVisible()"
+  [dateTime]="dateTime()"
   (openForm)="openForm()"
   (closeForm)="closeForm()"
   (create)="onCreate($event)"></app-schedule-layout>

--- a/asobi-fe/asobi-project-fe/src/app/page/schedule/schedule-page.component.ts
+++ b/asobi-fe/asobi-project-fe/src/app/page/schedule/schedule-page.component.ts
@@ -3,6 +3,8 @@ import { ScheduleLayoutComponent } from '../../view/layouts/schedule-layout/sche
 import { ScheduleService } from '../../domain/service/impl/schedule.service.impl';
 import { ScheduleState } from '../../domain/state/local/schedule.state';
 import { Task } from '../../domain/model/task';
+import { ClockService } from '../../domain/service/impl/clock.service.impl';
+import { ClockState } from '../../domain/state/global/clock.state';
 
 @Component({
   selector: 'app-schedule-page',
@@ -14,11 +16,15 @@ import { Task } from '../../domain/model/task';
 export class SchedulePageComponent implements OnInit {
   #service = inject(ScheduleService);
   #state = inject(ScheduleState);
+  #clockService = inject(ClockService);
+  #clockState = inject(ClockState);
   protected tasks = this.#state.tasks;
   protected isFormVisible = signal(false);
+  protected dateTime = this.#clockState.now;
 
   ngOnInit(): void {
     this.#service.load();
+    this.#clockService.start();
   }
 
   openForm(): void {

--- a/asobi-fe/asobi-project-fe/src/app/view/layouts/schedule-layout/schedule-layout.component.html
+++ b/asobi-fe/asobi-project-fe/src/app/view/layouts/schedule-layout/schedule-layout.component.html
@@ -17,4 +17,5 @@
       </div>
     }
   </div>
+  <app-footer [dateTime]="dateTime"></app-footer>
 </div>

--- a/asobi-fe/asobi-project-fe/src/app/view/layouts/schedule-layout/schedule-layout.component.ts
+++ b/asobi-fe/asobi-project-fe/src/app/view/layouts/schedule-layout/schedule-layout.component.ts
@@ -3,11 +3,12 @@ import { Task } from '../../../domain/model/task';
 import { GanttChartComponent } from '../../parts/gantt-chart/gantt-chart.component';
 import { TaskFormComponent } from '../../parts/task-form/task-form.component';
 import { HeaderComponent } from '../../parts/header/header.component';
+import { FooterComponent } from '../../parts/footer/footer.component';
 
 @Component({
   selector: 'app-schedule-layout',
   standalone: true,
-  imports: [HeaderComponent, GanttChartComponent, TaskFormComponent],
+  imports: [HeaderComponent, GanttChartComponent, TaskFormComponent, FooterComponent],
   changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: './schedule-layout.component.html',
   styleUrl: './schedule-layout.component.scss'
@@ -15,6 +16,7 @@ import { HeaderComponent } from '../../parts/header/header.component';
 export class ScheduleLayoutComponent {
   @Input({ required: true }) tasks: Task[] = [];
   @Input() formVisible = false;
+  @Input() dateTime = '';
   @Output() create = new EventEmitter<Task>();
   @Output() openForm = new EventEmitter<void>();
   @Output() closeForm = new EventEmitter<void>();

--- a/asobi-fe/asobi-project-fe/src/app/view/parts/footer/footer.component.html
+++ b/asobi-fe/asobi-project-fe/src/app/view/parts/footer/footer.component.html
@@ -1,0 +1,3 @@
+<footer class="footer">
+  <span>{{ dateTime }}</span>
+</footer>

--- a/asobi-fe/asobi-project-fe/src/app/view/parts/footer/footer.component.scss
+++ b/asobi-fe/asobi-project-fe/src/app/view/parts/footer/footer.component.scss
@@ -1,0 +1,6 @@
+.footer {
+  background: #000;
+  color: #fff;
+  text-align: right;
+  padding: 0.5rem 1rem;
+}

--- a/asobi-fe/asobi-project-fe/src/app/view/parts/footer/footer.component.ts
+++ b/asobi-fe/asobi-project-fe/src/app/view/parts/footer/footer.component.ts
@@ -1,0 +1,12 @@
+import { ChangeDetectionStrategy, Component, Input } from '@angular/core';
+
+@Component({
+  selector: 'app-footer',
+  standalone: true,
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  templateUrl: './footer.component.html',
+  styleUrl: './footer.component.scss'
+})
+export class FooterComponent {
+  @Input({ required: true }) dateTime = '';
+}


### PR DESCRIPTION
## Summary
- フッターを追加し、現在の年月日時分を黒地に白文字で表示
- ClockStateとClockServiceで現在時刻を管理し、レイアウトとページに連携

## Testing
- `npm test -- --watch=false --browsers=ChromeHeadless` (Chrome未設定のため失敗)


------
https://chatgpt.com/codex/tasks/task_e_689a816d1c8c83318f87592d821f676f