### PR TITLE
fix: ガントチャートの縦スクロール同期

### DIFF
--- a/asobi-fe/asobi-project-fe/src/app/view/parts/gantt-chart/gantt-chart.component.ts
+++ b/asobi-fe/asobi-project-fe/src/app/view/parts/gantt-chart/gantt-chart.component.ts
@@ -31,7 +31,6 @@ export class GanttChartComponent implements AfterViewInit, OnChanges {
   protected dateRange: Date[] = [];
   private rangeStart: Date;
   private rangeEnd: Date;
-  private isSyncing = false;
 
   constructor(private cdr: ChangeDetectorRef) {
     const start = new Date(this.today);
@@ -97,12 +96,9 @@ export class GanttChartComponent implements AfterViewInit, OnChanges {
     const taskEl = this.taskArea.nativeElement;
 
     chartEl.addEventListener('scroll', () => {
-      if (this.isSyncing) {
-        this.isSyncing = false;
-        return;
+      if (taskEl.scrollTop !== chartEl.scrollTop) {
+        taskEl.scrollTop = chartEl.scrollTop;
       }
-      this.isSyncing = true;
-      taskEl.scrollTop = chartEl.scrollTop;
 
       if (chartEl.scrollLeft + chartEl.clientWidth >= chartEl.scrollWidth - 100) {
         this.extendRight(365);
@@ -114,12 +110,9 @@ export class GanttChartComponent implements AfterViewInit, OnChanges {
     });
 
     taskEl.addEventListener('scroll', () => {
-      if (this.isSyncing) {
-        this.isSyncing = false;
-        return;
+      if (chartEl.scrollTop !== taskEl.scrollTop) {
+        chartEl.scrollTop = taskEl.scrollTop;
       }
-      this.isSyncing = true;
-      chartEl.scrollTop = taskEl.scrollTop;
     });
   }
 


### PR DESCRIPTION
## Summary
- タスク表と日付エリアの縦スクロールが連動するよう修正

## Testing
- `npm test -- --watch=false --browsers=ChromeHeadless` (ChromeHeadless が root 実行かつ --no-sandbox 未指定のため起動失敗)


------
https://chatgpt.com/codex/tasks/task_e_689a814abc748331b08ab5c21a6ad0f9