### PR TITLE
refactor: route state access through services

### DIFF
--- a/asobi-fe/asobi-project-fe/src/app/domain/service/impl/clock.service.impl.ts
+++ b/asobi-fe/asobi-project-fe/src/app/domain/service/impl/clock.service.impl.ts
@@ -5,6 +5,7 @@ import { ClockState } from '../../state/global/clock.state';
 @Injectable({ providedIn: 'root' })
 export class ClockService implements ClockServiceInterface {
   #state = inject(ClockState);
+  readonly now = this.#state.now;
 
   start(): void {
     this.#update();

--- a/asobi-fe/asobi-project-fe/src/app/domain/service/impl/schedule.service.impl.ts
+++ b/asobi-fe/asobi-project-fe/src/app/domain/service/impl/schedule.service.impl.ts
@@ -8,6 +8,7 @@ import { ScheduleState } from '../../state/local/schedule.state';
 export class ScheduleService implements ScheduleServiceInterface {
   #repository = inject(ScheduleRepository);
   #state = inject(ScheduleState);
+  readonly tasks = this.#state.tasks;
 
   async load(): Promise<void> {
     const tasks = await this.#repository.findAll();

--- a/asobi-fe/asobi-project-fe/src/app/domain/service/interface/clock.service.ts
+++ b/asobi-fe/asobi-project-fe/src/app/domain/service/interface/clock.service.ts
@@ -1,3 +1,6 @@
+import { Signal } from '@angular/core';
+
 export interface ClockServiceInterface {
+  readonly now: Signal<string>;
   start(): void;
 }

--- a/asobi-fe/asobi-project-fe/src/app/domain/service/interface/schedule.service.ts
+++ b/asobi-fe/asobi-project-fe/src/app/domain/service/interface/schedule.service.ts
@@ -1,6 +1,8 @@
 import { Task } from '../../model/task';
+import { Signal } from '@angular/core';
 
 export interface ScheduleServiceInterface {
+  readonly tasks: Signal<Task[]>;
   load(): Promise<void>;
   add(task: Task): Promise<void>;
   update(task: Task): Promise<void>;

--- a/asobi-fe/asobi-project-fe/src/app/page/schedule/schedule-page.component.ts
+++ b/asobi-fe/asobi-project-fe/src/app/page/schedule/schedule-page.component.ts
@@ -1,10 +1,8 @@
 import { ChangeDetectionStrategy, Component, OnInit, inject, signal } from '@angular/core';
 import { ScheduleLayoutComponent } from '../../view/layouts/schedule-layout/schedule-layout.component';
 import { ScheduleService } from '../../domain/service/impl/schedule.service.impl';
-import { ScheduleState } from '../../domain/state/local/schedule.state';
 import { Task } from '../../domain/model/task';
 import { ClockService } from '../../domain/service/impl/clock.service.impl';
-import { ClockState } from '../../domain/state/global/clock.state';
 
 @Component({
   selector: 'app-schedule-page',
@@ -14,16 +12,14 @@ import { ClockState } from '../../domain/state/global/clock.state';
   templateUrl: './schedule-page.component.html'
 })
 export class SchedulePageComponent implements OnInit {
-  #service = inject(ScheduleService);
-  #state = inject(ScheduleState);
+  #scheduleService = inject(ScheduleService);
   #clockService = inject(ClockService);
-  #clockState = inject(ClockState);
-  protected tasks = this.#state.tasks;
+  protected tasks = this.#scheduleService.tasks;
   protected isFormVisible = signal(false);
-  protected dateTime = this.#clockState.now;
+  protected dateTime = this.#clockService.now;
 
   ngOnInit(): void {
-    this.#service.load();
+    this.#scheduleService.load();
     this.#clockService.start();
   }
 
@@ -36,7 +32,7 @@ export class SchedulePageComponent implements OnInit {
   }
 
   onCreate(task: Task): void {
-    this.#service.add(task);
+    this.#scheduleService.add(task);
     this.closeForm();
   }
 }


### PR DESCRIPTION
## Summary
- expose clock and schedule state via services
- remove direct state injection from SchedulePage component

## Testing
- `CHROME_BIN=$(which chromium-browser) npm test -- --watch=false --browsers=ChromeHeadless` *(fails: Command '/usr/bin/chromium-browser' requires the chromium snap to be installed)*

------
https://chatgpt.com/codex/tasks/task_e_689a8bdfeabc833180d8afe6e7c4f8db