### PR TITLE
モダンなUIデザインへの刷新

### DIFF
--- a/asobi-fe/asobi-project-fe/public/logo.svg
+++ b/asobi-fe/asobi-project-fe/public/logo.svg
@@ -1,0 +1,5 @@
+<svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <rect x="2" y="7" width="20" height="10" rx="5" ry="5"/>
+  <circle cx="8" cy="12" r="1.5" fill="currentColor" stroke="none"/>
+  <path d="M15 12h3M16.5 10.5v3"/>
+</svg>

--- a/asobi-fe/asobi-project-fe/src/app/view/parts/gantt-chart/gantt-chart.component.scss
+++ b/asobi-fe/asobi-project-fe/src/app/view/parts/gantt-chart/gantt-chart.component.scss
@@ -7,9 +7,9 @@
   display: flex;
   width: 100%;
   height: 100%;
-  border: 1px solid #ddd;
+  border: 1px solid #e5e7eb;
   border-radius: 8px;
-  background: #fafafa;
+  background: #fff;
 }
 
 .task-area {
@@ -46,7 +46,7 @@
 
 th,
 td {
-  border: 1px solid #e0e0e0;
+  border: 1px solid #e5e7eb;
   padding: 4px;
   text-align: center;
   white-space: nowrap;
@@ -71,7 +71,7 @@ td {
 .chart-table thead th {
   position: sticky;
   top: 0;
-  background: #e3f2fd;
+  background: #f3f4f6;
   z-index: 1;
 }
 
@@ -111,16 +111,16 @@ td {
 }
 
 .day.progress {
-  background-color: #42a5f5;
+  background-color: var(--color-primary);
 }
 
 .day.planned {
-  background-color: #90caf9;
+  background-color: #93c5fd;
 }
 
 .task-table tbody tr:nth-child(even),
 .chart-table tbody tr:nth-child(even) {
-  background: #f9f9f9;
+  background: #f5f5f5;
 }
 
 

--- a/asobi-fe/asobi-project-fe/src/app/view/parts/header/header.component.html
+++ b/asobi-fe/asobi-project-fe/src/app/view/parts/header/header.component.html
@@ -1,10 +1,7 @@
 <header class="header">
   <div class="title">
-    <span class="logo" aria-hidden="true">🎮</span>
-    <span>asobi</span>
+    <img src="logo.svg" alt="asobi" class="logo" />
+    <span class="app-name">asobi</span>
   </div>
-  <button class="logout" (click)="logout.emit()">
-    <span class="logo" aria-hidden="true">🚪</span>
-    ログアウト
-  </button>
+  <button class="logout" (click)="logout.emit()">ログアウト</button>
 </header>

--- a/asobi-fe/asobi-project-fe/src/app/view/parts/header/header.component.scss
+++ b/asobi-fe/asobi-project-fe/src/app/view/parts/header/header.component.scss
@@ -1,5 +1,5 @@
 .header {
-  background: #000;
+  background: linear-gradient(90deg, #1f2937, #111827);
   color: #fff;
   display: flex;
   justify-content: space-between;
@@ -14,15 +14,26 @@
   gap: 0.5rem;
 }
 
+.app-name {
+  font-size: 1.5rem;
+  font-weight: 600;
+}
+
 .logout {
-  background: transparent;
-  border: 1px solid #fff;
+  background: var(--color-primary);
+  border: none;
   color: #fff;
-  padding: 0.25rem 0.75rem;
-  border-radius: 4px;
+  padding: 0.4rem 0.9rem;
+  border-radius: 6px;
   cursor: pointer;
+  transition: background-color 0.2s;
+}
+
+.logout:hover {
+  background: #2563eb;
 }
 
 .logo {
-  font-size: 1.2rem;
+  width: 24px;
+  height: 24px;
 }

--- a/asobi-fe/asobi-project-fe/src/styles.scss
+++ b/asobi-fe/asobi-project-fe/src/styles.scss
@@ -1,21 +1,28 @@
-/* You can add global styles to this file, and also import other style files */
+/* Global style definitions */
+
+:root {
+  --color-bg: #f5f5f9;
+  --color-primary: #3b82f6;
+  --color-text: #333;
+}
 
 body {
   margin: 0;
-  font-family: Arial, Helvetica, sans-serif;
-  background-color: #f0f2f5;
-  color: #333;
+  font-family: 'Segoe UI', Arial, sans-serif;
+  background-color: var(--color-bg);
+  color: var(--color-text);
 }
 
 button {
   padding: 0.5rem 1rem;
   border: none;
-  border-radius: 4px;
-  background-color: #1976d2;
+  border-radius: 6px;
+  background: var(--color-primary);
   color: #fff;
   cursor: pointer;
+  transition: background-color 0.2s;
 }
 
 button:hover {
-  background-color: #1565c0;
+  background: #2563eb;
 }


### PR DESCRIPTION
## 概要
- ヘッダーのロゴをピクトグラム化し、フォントサイズを拡大
- カラーリングとボタンデザインを刷新
- ガントチャートの配色をモダンなスタイルに調整

## テスト
- `npm test`（Chromeが存在しないため失敗）

------
https://chatgpt.com/codex/tasks/task_e_689a94aa0c9483319320756541a00934