### PR TITLE
ロゴカラーの改善で暗色背景での視認性を向上

### DIFF
--- a/asobi-fe/asobi-project-fe/public/logo.svg
+++ b/asobi-fe/asobi-project-fe/public/logo.svg
@@ -1,5 +1,5 @@
-<svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+<svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" fill="none" stroke="#fff" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
   <rect x="2" y="7" width="20" height="10" rx="5" ry="5"/>
-  <circle cx="8" cy="12" r="1.5" fill="currentColor" stroke="none"/>
+  <circle cx="8" cy="12" r="1.5" fill="#fff" stroke="none"/>
   <path d="M15 12h3M16.5 10.5v3"/>
 </svg>


### PR DESCRIPTION
## 概要
- 暗い背景でも見やすくなるようにロゴの線と塗りを白に変更

## テスト
- `npm test -- --watch=false --browsers=ChromeHeadless` を実行（ChromeHeadless のバイナリが見つからず失敗）

------
https://chatgpt.com/codex/tasks/task_e_689a97c08394833184a5ecd34d8d6d54