### PR TITLE
fix: ガントチャートヘッダーのスクロールずれを解消

### DIFF
--- a/asobi-fe/asobi-project-fe/src/app/view/parts/gantt-chart/gantt-chart.component.ts
+++ b/asobi-fe/asobi-project-fe/src/app/view/parts/gantt-chart/gantt-chart.component.ts
@@ -98,8 +98,12 @@ export class GanttChartComponent implements AfterViewInit, OnChanges {
     const taskEl = this.taskArea.nativeElement;
 
     chartEl.addEventListener('scroll', () => {
-      if (taskEl.scrollTop !== chartEl.scrollTop) {
-        taskEl.scrollTop = chartEl.scrollTop;
+      const scrollTop = Math.round(chartEl.scrollTop);
+      if (chartEl.scrollTop !== scrollTop) {
+        chartEl.scrollTop = scrollTop;
+      }
+      if (taskEl.scrollTop !== scrollTop) {
+        taskEl.scrollTop = scrollTop;
       }
 
       if (
@@ -115,8 +119,12 @@ export class GanttChartComponent implements AfterViewInit, OnChanges {
     });
 
     taskEl.addEventListener('scroll', () => {
-      if (chartEl.scrollTop !== taskEl.scrollTop) {
-        chartEl.scrollTop = taskEl.scrollTop;
+      const scrollTop = Math.round(taskEl.scrollTop);
+      if (taskEl.scrollTop !== scrollTop) {
+        taskEl.scrollTop = scrollTop;
+      }
+      if (chartEl.scrollTop !== scrollTop) {
+        chartEl.scrollTop = scrollTop;
       }
     });
   }


### PR DESCRIPTION
## Summary
- ガントチャートのスクロール同期時に小数が混入しないよう丸め処理を追加
- ヘッダーの日付行が縦スクロールで動く現象を解消

## Testing
- `npm test` (Chrome未インストールのため失敗)
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689a9860c638833186021da2ca4130f3