### PR TITLE
fix: ensure today column aligns with tasks

### DIFF
--- a/asobi-fe/asobi-project-fe/src/app/view/parts/gantt-chart/gantt-chart.component.ts
+++ b/asobi-fe/asobi-project-fe/src/app/view/parts/gantt-chart/gantt-chart.component.ts
@@ -83,8 +83,14 @@ export class GanttChartComponent implements AfterViewInit, OnChanges {
     if (index < 0) {
       return;
     }
-    const dayWidth = 38; // cell width + border
-    this.chartArea.nativeElement.scrollLeft = index * dayWidth;
+    requestAnimationFrame(() => {
+      const chartEl = this.chartArea!.nativeElement;
+      const selector = `.chart-table tbody tr:first-child td:nth-child(${index + 1})`;
+      const cell = chartEl.querySelector<HTMLTableCellElement>(selector);
+      if (cell) {
+        chartEl.scrollLeft = cell.offsetLeft;
+      }
+    });
   }
 
   private setupScrollSync(): void {


### PR DESCRIPTION
## Summary
- 今日の列をタスク情報の直後に表示するようスクロール位置を計算

## Testing
- `npm test -- --watch=false --browsers=ChromeHeadless` *(失敗: Command '/usr/bin/chromium-browser' requires the chromium snap to be installed)*

------
https://chatgpt.com/codex/tasks/task_e_689aa84ca3a083318f17ef51a393353b