### PR TITLE
feat: fetch tasks from mock api

### DIFF
--- a/asobi-fe/asobi-project-fe/src/app/app.config.ts
+++ b/asobi-fe/asobi-project-fe/src/app/app.config.ts
@@ -1,5 +1,6 @@
 import { ApplicationConfig, provideBrowserGlobalErrorListeners, provideZonelessChangeDetection } from '@angular/core';
 import { provideRouter } from '@angular/router';
+import { provideHttpClient } from '@angular/common/http';
 
 import { routes } from './app.routes';
 
@@ -7,6 +8,7 @@ export const appConfig: ApplicationConfig = {
   providers: [
     provideBrowserGlobalErrorListeners(),
     provideZonelessChangeDetection(),
-    provideRouter(routes)
+    provideRouter(routes),
+    provideHttpClient()
   ]
 };

--- a/asobi-fe/asobi-project-fe/src/app/infrastructure/api/schedule.api.ts
+++ b/asobi-fe/asobi-project-fe/src/app/infrastructure/api/schedule.api.ts
@@ -1,23 +1,58 @@
-import { Injectable } from '@angular/core';
+import { Injectable, inject } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { firstValueFrom } from 'rxjs';
 import { Task } from '../../domain/model/task';
+
+interface ApiTask {
+  id: number;
+  title: string;
+  phase: string;
+  startDate: string;
+  endDate: string;
+}
 
 @Injectable({ providedIn: 'root' })
 export class ScheduleApi {
-  #tasks: Task[] = [];
+  #http = inject(HttpClient);
+  readonly #baseUrl = 'http://localhost:3000/tasks';
 
   async list(): Promise<Task[]> {
-    return this.#tasks;
+    const apiTasks = await firstValueFrom(this.#http.get<ApiTask[]>(this.#baseUrl));
+    return apiTasks.map(t => ({
+      id: String(t.id),
+      type: t.phase,
+      name: t.title,
+      detail: '',
+      assignee: '',
+      start: new Date(t.startDate),
+      end: new Date(t.endDate),
+      progress: 0
+    }));
   }
 
   async create(task: Task): Promise<void> {
-    this.#tasks.push(task);
+    const body: ApiTask = {
+      id: Number(task.id),
+      title: task.name,
+      phase: task.type,
+      startDate: task.start.toISOString().split('T')[0],
+      endDate: task.end.toISOString().split('T')[0]
+    };
+    await firstValueFrom(this.#http.post<ApiTask>(this.#baseUrl, body));
   }
 
   async update(task: Task): Promise<void> {
-    this.#tasks = this.#tasks.map(t => (t.id === task.id ? task : t));
+    const body: ApiTask = {
+      id: Number(task.id),
+      title: task.name,
+      phase: task.type,
+      startDate: task.start.toISOString().split('T')[0],
+      endDate: task.end.toISOString().split('T')[0]
+    };
+    await firstValueFrom(this.#http.put<ApiTask>(`${this.#baseUrl}/${task.id}`, body));
   }
 
   async delete(id: string): Promise<void> {
-    this.#tasks = this.#tasks.filter(t => t.id !== id);
+    await firstValueFrom(this.#http.delete(`${this.#baseUrl}/${id}`));
   }
 }


### PR DESCRIPTION
## Summary
- use HttpClient to load tasks from json-server mock API
- expose HttpClient to application via app config

## Testing
- `npm test` *(fails: No binary for Chrome browser)*

------
https://chatgpt.com/codex/tasks/task_e_689aa88021e88331be18f9a07df83c76