### PR TITLE
モックデータを2025年スケジュールに更新

### DIFF
--- a/asobi-fe/asobi-project-fe/mock/db.json
+++ b/asobi-fe/asobi-project-fe/mock/db.json
@@ -2,353 +2,403 @@
   "tasks": [
     {
       "id": 1,
-      "title": "Requirements Task 1",
-      "phase": "requirements",
-      "startDate": "2024-01-01",
-      "endDate": "2024-01-03"
+      "title": "顧客ヒアリング",
+      "phase": "要件定義",
+      "assignee": "佐藤太郎",
+      "startDate": "2025-08-12",
+      "endDate": "2025-08-14"
     },
     {
       "id": 2,
-      "title": "Requirements Task 2",
-      "phase": "requirements",
-      "startDate": "2024-01-04",
-      "endDate": "2024-01-06"
+      "title": "業務フロー整理",
+      "phase": "要件定義",
+      "assignee": "鈴木花子",
+      "startDate": "2025-08-14",
+      "endDate": "2025-08-16"
     },
     {
       "id": 3,
-      "title": "Requirements Task 3",
-      "phase": "requirements",
-      "startDate": "2024-01-07",
-      "endDate": "2024-01-09"
+      "title": "要件定義書ドラフト",
+      "phase": "要件定義",
+      "assignee": "高橋健",
+      "startDate": "2025-08-16",
+      "endDate": "2025-08-21"
     },
     {
       "id": 4,
-      "title": "Requirements Task 4",
-      "phase": "requirements",
-      "startDate": "2024-01-10",
-      "endDate": "2024-01-12"
+      "title": "ステークホルダレビュー",
+      "phase": "要件定義",
+      "assignee": "田中美咲",
+      "startDate": "2025-08-23",
+      "endDate": "2025-08-28"
     },
     {
       "id": 5,
-      "title": "Requirements Task 5",
-      "phase": "requirements",
-      "startDate": "2024-01-13",
-      "endDate": "2024-01-15"
+      "title": "要件確定",
+      "phase": "要件定義",
+      "assignee": "伊藤大輔",
+      "startDate": "2025-08-30",
+      "endDate": "2025-09-01"
     },
     {
       "id": 6,
-      "title": "Requirements Task 6",
-      "phase": "requirements",
-      "startDate": "2024-01-16",
-      "endDate": "2024-01-18"
+      "title": "リスク分析",
+      "phase": "要件定義",
+      "assignee": "山本彩",
+      "startDate": "2025-09-03",
+      "endDate": "2025-09-06"
     },
     {
       "id": 7,
-      "title": "Requirements Task 7",
-      "phase": "requirements",
-      "startDate": "2024-01-19",
-      "endDate": "2024-01-21"
+      "title": "優先順位付け",
+      "phase": "要件定義",
+      "assignee": "小林誠",
+      "startDate": "2025-09-07",
+      "endDate": "2025-09-12"
     },
     {
       "id": 8,
-      "title": "Requirements Task 8",
-      "phase": "requirements",
-      "startDate": "2024-01-22",
-      "endDate": "2024-01-24"
+      "title": "要求仕様書作成",
+      "phase": "要件定義",
+      "assignee": "中村明",
+      "startDate": "2025-09-13",
+      "endDate": "2025-09-18"
     },
     {
       "id": 9,
-      "title": "Requirements Task 9",
-      "phase": "requirements",
-      "startDate": "2024-01-25",
-      "endDate": "2024-01-27"
+      "title": "承認プロセス",
+      "phase": "要件定義",
+      "assignee": "加藤直樹",
+      "startDate": "2025-09-18",
+      "endDate": "2025-09-23"
     },
     {
       "id": 10,
-      "title": "Requirements Task 10",
-      "phase": "requirements",
-      "startDate": "2024-01-28",
-      "endDate": "2024-01-30"
+      "title": "要件サインオフ",
+      "phase": "要件定義",
+      "assignee": "吉田光",
+      "startDate": "2025-09-24",
+      "endDate": "2025-09-29"
     },
     {
       "id": 11,
-      "title": "Design Task 1",
-      "phase": "design",
-      "startDate": "2024-02-01",
-      "endDate": "2024-02-03"
+      "title": "画面設計",
+      "phase": "設計",
+      "assignee": "佐藤太郎",
+      "startDate": "2025-09-30",
+      "endDate": "2025-10-03"
     },
     {
       "id": 12,
-      "title": "Design Task 2",
-      "phase": "design",
-      "startDate": "2024-02-04",
-      "endDate": "2024-02-06"
+      "title": "DB設計",
+      "phase": "設計",
+      "assignee": "鈴木花子",
+      "startDate": "2025-10-03",
+      "endDate": "2025-10-05"
     },
     {
       "id": 13,
-      "title": "Design Task 3",
-      "phase": "design",
-      "startDate": "2024-02-07",
-      "endDate": "2024-02-09"
+      "title": "アーキテクチャ設計",
+      "phase": "設計",
+      "assignee": "高橋健",
+      "startDate": "2025-10-07",
+      "endDate": "2025-10-11"
     },
     {
       "id": 14,
-      "title": "Design Task 4",
-      "phase": "design",
-      "startDate": "2024-02-10",
-      "endDate": "2024-02-12"
+      "title": "UIプロトタイプ作成",
+      "phase": "設計",
+      "assignee": "田中美咲",
+      "startDate": "2025-10-11",
+      "endDate": "2025-10-13"
     },
     {
       "id": 15,
-      "title": "Design Task 5",
-      "phase": "design",
-      "startDate": "2024-02-13",
-      "endDate": "2024-02-15"
+      "title": "レビュー対応",
+      "phase": "設計",
+      "assignee": "伊藤大輔",
+      "startDate": "2025-10-14",
+      "endDate": "2025-10-19"
     },
     {
       "id": 16,
-      "title": "Design Task 6",
-      "phase": "design",
-      "startDate": "2024-02-16",
-      "endDate": "2024-02-18"
+      "title": "API仕様策定",
+      "phase": "設計",
+      "assignee": "山本彩",
+      "startDate": "2025-10-19",
+      "endDate": "2025-10-22"
     },
     {
       "id": 17,
-      "title": "Design Task 7",
-      "phase": "design",
-      "startDate": "2024-02-19",
-      "endDate": "2024-02-21"
+      "title": "ユースケース作成",
+      "phase": "設計",
+      "assignee": "小林誠",
+      "startDate": "2025-10-23",
+      "endDate": "2025-10-28"
     },
     {
       "id": 18,
-      "title": "Design Task 8",
-      "phase": "design",
-      "startDate": "2024-02-22",
-      "endDate": "2024-02-24"
+      "title": "設計書レビュー",
+      "phase": "設計",
+      "assignee": "中村明",
+      "startDate": "2025-10-29",
+      "endDate": "2025-10-31"
     },
     {
       "id": 19,
-      "title": "Design Task 9",
-      "phase": "design",
-      "startDate": "2024-02-25",
-      "endDate": "2024-02-27"
+      "title": "設計修正",
+      "phase": "設計",
+      "assignee": "加藤直樹",
+      "startDate": "2025-11-01",
+      "endDate": "2025-11-06"
     },
     {
       "id": 20,
-      "title": "Design Task 10",
-      "phase": "design",
-      "startDate": "2024-02-28",
-      "endDate": "2024-03-01"
+      "title": "設計確定",
+      "phase": "設計",
+      "assignee": "吉田光",
+      "startDate": "2025-11-06",
+      "endDate": "2025-11-09"
     },
     {
       "id": 21,
-      "title": "Implementation Task 1",
-      "phase": "implementation",
-      "startDate": "2024-03-01",
-      "endDate": "2024-03-03"
+      "title": "ログイン機能実装",
+      "phase": "実装",
+      "assignee": "佐藤太郎",
+      "startDate": "2025-11-09",
+      "endDate": "2025-11-12"
     },
     {
       "id": 22,
-      "title": "Implementation Task 2",
-      "phase": "implementation",
-      "startDate": "2024-03-04",
-      "endDate": "2024-03-06"
+      "title": "ユーザー登録機能実装",
+      "phase": "実装",
+      "assignee": "鈴木花子",
+      "startDate": "2025-11-13",
+      "endDate": "2025-11-16"
     },
     {
       "id": 23,
-      "title": "Implementation Task 3",
-      "phase": "implementation",
-      "startDate": "2024-03-07",
-      "endDate": "2024-03-09"
+      "title": "認証ミドルウェア整備",
+      "phase": "実装",
+      "assignee": "高橋健",
+      "startDate": "2025-11-18",
+      "endDate": "2025-11-20"
     },
     {
       "id": 24,
-      "title": "Implementation Task 4",
-      "phase": "implementation",
-      "startDate": "2024-03-10",
-      "endDate": "2024-03-12"
+      "title": "ダッシュボード画面実装",
+      "phase": "実装",
+      "assignee": "田中美咲",
+      "startDate": "2025-11-21",
+      "endDate": "2025-11-24"
     },
     {
       "id": 25,
-      "title": "Implementation Task 5",
-      "phase": "implementation",
-      "startDate": "2024-03-13",
-      "endDate": "2024-03-15"
+      "title": "検索機能実装",
+      "phase": "実装",
+      "assignee": "伊藤大輔",
+      "startDate": "2025-11-26",
+      "endDate": "2025-11-30"
     },
     {
       "id": 26,
-      "title": "Implementation Task 6",
-      "phase": "implementation",
-      "startDate": "2024-03-16",
-      "endDate": "2024-03-18"
+      "title": "ページング機能実装",
+      "phase": "実装",
+      "assignee": "山本彩",
+      "startDate": "2025-12-02",
+      "endDate": "2025-12-04"
     },
     {
       "id": 27,
-      "title": "Implementation Task 7",
-      "phase": "implementation",
-      "startDate": "2024-03-19",
-      "endDate": "2024-03-21"
+      "title": "通知機能実装",
+      "phase": "実装",
+      "assignee": "小林誠",
+      "startDate": "2025-12-06",
+      "endDate": "2025-12-11"
     },
     {
       "id": 28,
-      "title": "Implementation Task 8",
-      "phase": "implementation",
-      "startDate": "2024-03-22",
-      "endDate": "2024-03-24"
+      "title": "ファイルアップロード機能実装",
+      "phase": "実装",
+      "assignee": "中村明",
+      "startDate": "2025-12-11",
+      "endDate": "2025-12-15"
     },
     {
       "id": 29,
-      "title": "Implementation Task 9",
-      "phase": "implementation",
-      "startDate": "2024-03-25",
-      "endDate": "2024-03-27"
+      "title": "権限管理機能実装",
+      "phase": "実装",
+      "assignee": "加藤直樹",
+      "startDate": "2025-12-17",
+      "endDate": "2025-12-19"
     },
     {
       "id": 30,
-      "title": "Implementation Task 10",
-      "phase": "implementation",
-      "startDate": "2024-03-28",
-      "endDate": "2024-03-30"
+      "title": "アカウント設定画面実装",
+      "phase": "実装",
+      "assignee": "吉田光",
+      "startDate": "2025-12-20",
+      "endDate": "2025-12-24"
     },
     {
       "id": 31,
-      "title": "Implementation Task 11",
-      "phase": "implementation",
-      "startDate": "2024-03-31",
-      "endDate": "2024-04-02"
+      "title": "メール送信機能実装",
+      "phase": "実装",
+      "assignee": "佐藤太郎",
+      "startDate": "2025-12-25",
+      "endDate": "2025-12-30"
     },
     {
       "id": 32,
-      "title": "Implementation Task 12",
-      "phase": "implementation",
-      "startDate": "2024-04-03",
-      "endDate": "2024-04-05"
+      "title": "パフォーマンス最適化",
+      "phase": "実装",
+      "assignee": "鈴木花子",
+      "startDate": "2025-12-30",
+      "endDate": "2026-01-03"
     },
     {
       "id": 33,
-      "title": "Implementation Task 13",
-      "phase": "implementation",
-      "startDate": "2024-04-06",
-      "endDate": "2024-04-08"
+      "title": "エラーハンドリング実装",
+      "phase": "実装",
+      "assignee": "高橋健",
+      "startDate": "2026-01-05",
+      "endDate": "2026-01-10"
     },
     {
       "id": 34,
-      "title": "Implementation Task 14",
-      "phase": "implementation",
-      "startDate": "2024-04-09",
-      "endDate": "2024-04-11"
+      "title": "レスポンシブ対応",
+      "phase": "実装",
+      "assignee": "田中美咲",
+      "startDate": "2026-01-11",
+      "endDate": "2026-01-13"
     },
     {
       "id": 35,
-      "title": "Implementation Task 15",
-      "phase": "implementation",
-      "startDate": "2024-04-12",
-      "endDate": "2024-04-14"
+      "title": "ログ出力機能実装",
+      "phase": "実装",
+      "assignee": "伊藤大輔",
+      "startDate": "2026-01-14",
+      "endDate": "2026-01-17"
     },
     {
       "id": 36,
-      "title": "Implementation Task 16",
-      "phase": "implementation",
-      "startDate": "2024-04-15",
-      "endDate": "2024-04-17"
+      "title": "キャッシュ機構導入",
+      "phase": "実装",
+      "assignee": "山本彩",
+      "startDate": "2026-01-19",
+      "endDate": "2026-01-22"
     },
     {
       "id": 37,
-      "title": "Implementation Task 17",
-      "phase": "implementation",
-      "startDate": "2024-04-18",
-      "endDate": "2024-04-20"
+      "title": "API連携実装",
+      "phase": "実装",
+      "assignee": "小林誠",
+      "startDate": "2026-01-24",
+      "endDate": "2026-01-28"
     },
     {
       "id": 38,
-      "title": "Implementation Task 18",
-      "phase": "implementation",
-      "startDate": "2024-04-21",
-      "endDate": "2024-04-23"
+      "title": "ユニットテスト作成",
+      "phase": "実装",
+      "assignee": "中村明",
+      "startDate": "2026-01-30",
+      "endDate": "2026-02-04"
     },
     {
       "id": 39,
-      "title": "Implementation Task 19",
-      "phase": "implementation",
-      "startDate": "2024-04-24",
-      "endDate": "2024-04-26"
+      "title": "コードレビュー対応",
+      "phase": "実装",
+      "assignee": "加藤直樹",
+      "startDate": "2026-02-05",
+      "endDate": "2026-02-09"
     },
     {
       "id": 40,
-      "title": "Implementation Task 20",
-      "phase": "implementation",
-      "startDate": "2024-04-27",
-      "endDate": "2024-04-29"
+      "title": "実装完了",
+      "phase": "実装",
+      "assignee": "吉田光",
+      "startDate": "2026-02-10",
+      "endDate": "2026-02-15"
     },
     {
       "id": 41,
-      "title": "Testing Task 1",
-      "phase": "testing",
-      "startDate": "2024-05-01",
-      "endDate": "2024-05-03"
+      "title": "テスト計画作成",
+      "phase": "テスト",
+      "assignee": "佐藤太郎",
+      "startDate": "2026-02-17",
+      "endDate": "2026-02-22"
     },
     {
       "id": 42,
-      "title": "Testing Task 2",
-      "phase": "testing",
-      "startDate": "2024-05-04",
-      "endDate": "2024-05-06"
+      "title": "単体テスト実施",
+      "phase": "テスト",
+      "assignee": "鈴木花子",
+      "startDate": "2026-02-22",
+      "endDate": "2026-02-27"
     },
     {
       "id": 43,
-      "title": "Testing Task 3",
-      "phase": "testing",
-      "startDate": "2024-05-07",
-      "endDate": "2024-05-09"
+      "title": "結合テスト実施",
+      "phase": "テスト",
+      "assignee": "高橋健",
+      "startDate": "2026-02-27",
+      "endDate": "2026-03-02"
     },
     {
       "id": 44,
-      "title": "Testing Task 4",
-      "phase": "testing",
-      "startDate": "2024-05-10",
-      "endDate": "2024-05-12"
+      "title": "受け入れテスト調整",
+      "phase": "テスト",
+      "assignee": "田中美咲",
+      "startDate": "2026-03-03",
+      "endDate": "2026-03-05"
     },
     {
       "id": 45,
-      "title": "Testing Task 5",
-      "phase": "testing",
-      "startDate": "2024-05-13",
-      "endDate": "2024-05-15"
+      "title": "テスト結果レビュー",
+      "phase": "テスト",
+      "assignee": "伊藤大輔",
+      "startDate": "2026-03-05",
+      "endDate": "2026-03-09"
     },
     {
       "id": 46,
-      "title": "Deployment Task 1",
-      "phase": "deployment",
-      "startDate": "2024-06-01",
-      "endDate": "2024-06-03"
+      "title": "リリース手順作成",
+      "phase": "デプロイ",
+      "assignee": "山本彩",
+      "startDate": "2026-03-11",
+      "endDate": "2026-03-16"
     },
     {
       "id": 47,
-      "title": "Deployment Task 2",
-      "phase": "deployment",
-      "startDate": "2024-06-04",
-      "endDate": "2024-06-06"
+      "title": "ステージング反映",
+      "phase": "デプロイ",
+      "assignee": "小林誠",
+      "startDate": "2026-03-17",
+      "endDate": "2026-03-22"
     },
     {
       "id": 48,
-      "title": "Deployment Task 3",
-      "phase": "deployment",
-      "startDate": "2024-06-07",
-      "endDate": "2024-06-09"
+      "title": "本番リリース準備",
+      "phase": "デプロイ",
+      "assignee": "中村明",
+      "startDate": "2026-03-23",
+      "endDate": "2026-03-27"
     },
     {
       "id": 49,
-      "title": "Deployment Task 4",
-      "phase": "deployment",
-      "startDate": "2024-06-10",
-      "endDate": "2024-06-12"
+      "title": "リリース実施",
+      "phase": "デプロイ",
+      "assignee": "加藤直樹",
+      "startDate": "2026-03-29",
+      "endDate": "2026-03-31"
     },
     {
       "id": 50,
-      "title": "Deployment Task 5",
-      "phase": "deployment",
-      "startDate": "2024-06-13",
-      "endDate": "2024-06-15"
+      "title": "リリース後確認",
+      "phase": "デプロイ",
+      "assignee": "吉田光",
+      "startDate": "2026-04-02",
+      "endDate": "2026-04-05"
     }
   ]
 }


### PR DESCRIPTION
## 概要
- タスク分類・名称・担当者を日本語化
- 2025年8月12日から始まるモックデータへ更新し、期間をランダム化

## テスト
- `npm test -- --watch=false --browsers=ChromeHeadless` を実行し、Chromeのバイナリ不足で失敗することを確認

------
https://chatgpt.com/codex/tasks/task_e_689aac04db0c8331b5cafe8ffb84f22d