### PR TITLE
ログアウト表示とツールバーのデザインを刷新

### DIFF
--- a/asobi-fe/asobi-project-fe/public/add.svg
+++ b/asobi-fe/asobi-project-fe/public/add.svg
@@ -1,0 +1,4 @@
+<svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" fill="none" stroke="#fff" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <line x1="12" y1="5" x2="12" y2="19"/>
+  <line x1="5" y1="12" x2="19" y2="12"/>
+</svg>

--- a/asobi-fe/asobi-project-fe/public/logout.svg
+++ b/asobi-fe/asobi-project-fe/public/logout.svg
@@ -1,0 +1,5 @@
+<svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" fill="none" stroke="#fff" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <path d="M9 21H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h4"/>
+  <polyline points="16 17 21 12 16 7"/>
+  <line x1="21" y1="12" x2="9" y2="12"/>
+</svg>

--- a/asobi-fe/asobi-project-fe/public/today.svg
+++ b/asobi-fe/asobi-project-fe/public/today.svg
@@ -1,0 +1,7 @@
+<svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" fill="none" stroke="#fff" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <rect x="3" y="4" width="18" height="18" rx="2" ry="2"/>
+  <line x1="16" y1="2" x2="16" y2="6"/>
+  <line x1="8" y1="2" x2="8" y2="6"/>
+  <line x1="3" y1="10" x2="21" y2="10"/>
+  <rect x="10" y="14" width="4" height="4" fill="#fff" stroke="none"/>
+</svg>

--- a/asobi-fe/asobi-project-fe/src/app/view/layouts/schedule-layout/schedule-layout.component.html
+++ b/asobi-fe/asobi-project-fe/src/app/view/layouts/schedule-layout/schedule-layout.component.html
@@ -2,8 +2,14 @@
   <app-header></app-header>
   <div class="content">
     <div class="toolbar">
-      <button (click)="openForm.emit()">タスクを追加</button>
-      <button (click)="ganttChart.scrollToToday()">今日に戻る</button>
+      <button class="add-task" (click)="openForm.emit()">
+        <img src="add.svg" alt="" class="icon" />
+        タスクを追加
+      </button>
+      <button class="to-today secondary" (click)="ganttChart.scrollToToday()">
+        <img src="today.svg" alt="" class="icon" />
+        今日に戻る
+      </button>
     </div>
     <app-gantt-chart #ganttChart [tasks]="tasks"></app-gantt-chart>
     @if (formVisible) {

--- a/asobi-fe/asobi-project-fe/src/app/view/layouts/schedule-layout/schedule-layout.component.scss
+++ b/asobi-fe/asobi-project-fe/src/app/view/layouts/schedule-layout/schedule-layout.component.scss
@@ -13,8 +13,43 @@
 }
 
 .toolbar {
-  text-align: right;
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.5rem;
   padding: 0.5rem 1rem;
+}
+
+.toolbar button {
+  display: flex;
+  align-items: center;
+  gap: 0.25rem;
+  background: var(--color-primary);
+  border: none;
+  color: #fff;
+  padding: 0.4rem 0.8rem;
+  border-radius: 6px;
+  cursor: pointer;
+  transition: background-color 0.2s;
+}
+
+.toolbar button.secondary {
+  background: transparent;
+  border: 1px solid var(--color-primary);
+  color: var(--color-primary);
+}
+
+.toolbar button:hover {
+  background: #2563eb;
+}
+
+.toolbar button.secondary:hover {
+  background: var(--color-primary);
+  color: #fff;
+}
+
+.toolbar .icon {
+  width: 16px;
+  height: 16px;
 }
 
 app-gantt-chart {

--- a/asobi-fe/asobi-project-fe/src/app/view/parts/header/header.component.html
+++ b/asobi-fe/asobi-project-fe/src/app/view/parts/header/header.component.html
@@ -3,5 +3,8 @@
     <img src="logo.svg" alt="asobi" class="logo" />
     <span class="app-name">asobi</span>
   </div>
-  <button class="logout" (click)="logout.emit()">ログアウト</button>
+  <button class="logout" (click)="logout.emit()">
+    <img src="logout.svg" alt="" class="icon" />
+    <span>ログアウト</span>
+  </button>
 </header>

--- a/asobi-fe/asobi-project-fe/src/app/view/parts/header/header.component.scss
+++ b/asobi-fe/asobi-project-fe/src/app/view/parts/header/header.component.scss
@@ -20,20 +20,20 @@
 }
 
 .logout {
-  background: var(--color-primary);
+  background: none;
   border: none;
   color: #fff;
-  padding: 0.4rem 0.9rem;
-  border-radius: 6px;
+  padding: 0;
   cursor: pointer;
-  transition: background-color 0.2s;
+  transition: opacity 0.2s;
 }
 
 .logout:hover {
-  background: #2563eb;
+  opacity: 0.8;
 }
 
-.logo {
+.logo,
+.icon {
   width: 24px;
   height: 24px;
 }


### PR DESCRIPTION
## 概要
- ヘッダーのログアウト表示をアイコン＋テキストのスタイルに変更
- タスク追加／今日に戻るボタンをモダンな見た目へ改善しアイコンを追加

## テスト
- `npm test -- --watch=false --browsers=ChromeHeadless` (Chrome が見つからず失敗)


------
https://chatgpt.com/codex/tasks/task_e_689aaca0fc808331bd0ced005931ca3a