### PR TITLE
月切り替わり列の罫線を強調

### DIFF
--- a/asobi-fe/asobi-project-fe/src/app/view/parts/gantt-chart/gantt-chart.component.html
+++ b/asobi-fe/asobi-project-fe/src/app/view/parts/gantt-chart/gantt-chart.component.html
@@ -46,8 +46,12 @@
           }
         </tr>
         <tr>
-          @for (date of dateRange; track $index) {
-            <th class="date-col">{{ date | date:'dd' }}</th>
+          @for (date of dateRange; track $index; let i = $index) {
+            <th
+              class="date-col"
+              [class.month-boundary]="isMonthStart(date) && i !== 0"
+              >{{ date | date:'dd' }}</th
+            >
           }
         </tr>
       </thead>
@@ -55,12 +59,20 @@
         @for (row of emptyRows; track $index; let i = $index) {
           <tr>
             @if (tasks[i]; as task) {
-              @for (date of dateRange; track $index) {
-                <td class="day" [class.progress]="isProgress(task, date)" [class.planned]="isPlanned(task, date)"></td>
+              @for (date of dateRange; track $index; let j = $index) {
+                <td
+                  class="day"
+                  [class.progress]="isProgress(task, date)"
+                  [class.planned]="isPlanned(task, date)"
+                  [class.month-boundary]="isMonthStart(date) && j !== 0"
+                ></td>
               }
             } @else {
-              @for (date of dateRange; track $index) {
-                <td class="day"></td>
+              @for (date of dateRange; track $index; let j = $index) {
+                <td
+                  class="day"
+                  [class.month-boundary]="isMonthStart(date) && j !== 0"
+                ></td>
               }
             }
           </tr>

--- a/asobi-fe/asobi-project-fe/src/app/view/parts/gantt-chart/gantt-chart.component.scss
+++ b/asobi-fe/asobi-project-fe/src/app/view/parts/gantt-chart/gantt-chart.component.scss
@@ -96,6 +96,10 @@ td {
   padding: 0 4px;
 }
 
+.chart-table thead tr:first-child th:not(:first-child) {
+  border-left: 2px solid #9ca3af;
+}
+
 .type-col { min-width: 100px; }
 .name-col { min-width: 120px; }
 .detail-col { min-width: 180px; }
@@ -116,6 +120,10 @@ td {
 
 .day.planned {
   background-color: #93c5fd;
+}
+
+.month-boundary {
+  border-left: 2px solid #9ca3af;
 }
 
 .task-table tbody tr:nth-child(even),

--- a/asobi-fe/asobi-project-fe/src/app/view/parts/gantt-chart/gantt-chart.component.ts
+++ b/asobi-fe/asobi-project-fe/src/app/view/parts/gantt-chart/gantt-chart.component.ts
@@ -140,6 +140,10 @@ export class GanttChartComponent implements AfterViewInit, OnChanges {
     );
   }
 
+  protected isMonthStart(date: Date): boolean {
+    return date.getDate() === 1;
+  }
+
   isPlanned(task: Task, date: Date): boolean {
     const start = new Date(task.start);
     const end = new Date(task.end);


### PR DESCRIPTION
## 概要
- ガントチャートの日付列に月初判定を追加
- 月境界となる列に太い罫線を適用して視認性を向上

## テスト
- `npm test -- --watch=false --browsers=ChromeHeadless` (ChromeHeadlessのバイナリ欠如により失敗)


------
https://chatgpt.com/codex/tasks/task_e_689aad6c8a848331b464108885987c0f