### PR TITLE
ガントチャート列の調整と詳細列の削除

### DIFF
--- a/asobi-fe/asobi-project-fe/src/app/view/parts/gantt-chart/gantt-chart.component.html
+++ b/asobi-fe/asobi-project-fe/src/app/view/parts/gantt-chart/gantt-chart.component.html
@@ -5,7 +5,6 @@
         <tr>
           <th class="type-col">タスク分類</th>
           <th class="name-col">タスク名</th>
-          <th class="detail-col">タスク詳細</th>
           <th class="assignee-col">担当者</th>
           <th class="start-col">開始日</th>
           <th class="end-col">終了日</th>
@@ -18,7 +17,6 @@
             @if (tasks[i]; as task) {
               <td class="type-col">{{ task.type }}</td>
               <td class="name-col">{{ task.name }}</td>
-              <td class="detail-col">{{ task.detail }}</td>
               <td class="assignee-col">{{ task.assignee }}</td>
               <td class="start-col">{{ task.start | date:'yyyy-MM-dd' }}</td>
               <td class="end-col">{{ task.end | date:'yyyy-MM-dd' }}</td>
@@ -26,7 +24,6 @@
             } @else {
               <td class="type-col"></td>
               <td class="name-col"></td>
-              <td class="detail-col"></td>
               <td class="assignee-col"></td>
               <td class="start-col"></td>
               <td class="end-col"></td>

--- a/asobi-fe/asobi-project-fe/src/app/view/parts/gantt-chart/gantt-chart.component.scss
+++ b/asobi-fe/asobi-project-fe/src/app/view/parts/gantt-chart/gantt-chart.component.scss
@@ -13,7 +13,7 @@
 }
 
 .task-area {
-  flex: 0 0 780px;
+  flex: 0 0 710px;
   overflow-x: hidden;
   overflow-y: auto;
   height: 100%;
@@ -50,6 +50,8 @@ td {
   padding: 4px;
   text-align: center;
   white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 .task-table tbody tr,
@@ -96,13 +98,12 @@ td {
   padding: 0 4px;
 }
 
-.type-col { min-width: 100px; }
-.name-col { min-width: 120px; }
-.detail-col { min-width: 180px; }
-.assignee-col { min-width: 80px; }
-.start-col { min-width: 110px; }
-.end-col { min-width: 110px; }
-.progress-col { min-width: 80px; }
+.type-col { min-width: 150px; width: 150px; }
+.name-col { min-width: 200px; width: 200px; }
+.assignee-col { min-width: 80px; width: 80px; }
+.start-col { min-width: 110px; width: 110px; }
+.end-col { min-width: 110px; width: 110px; }
+.progress-col { min-width: 60px; width: 60px; }
 
 .day {
   width: 36px;


### PR DESCRIPTION
## Summary
- remove task detail column from Gantt table
- widen task classification/name columns and shrink progress width
- truncate overflowing cell text with ellipsis

## Testing
- `npm test -- --watch=false --browsers=ChromeHeadless` *(fails: No binary for ChromeHeadless browser on your platform)*

------
https://chatgpt.com/codex/tasks/task_e_689ab0a263788331ac9b9a5e1395a233