### PR TITLE
ガントチャートのタスク情報列の幅を調整

### DIFF
--- a/asobi-fe/asobi-project-fe/src/app/view/parts/gantt-chart/gantt-chart.component.scss
+++ b/asobi-fe/asobi-project-fe/src/app/view/parts/gantt-chart/gantt-chart.component.scss
@@ -13,7 +13,7 @@
 }
 
 .task-area {
-  flex: 0 0 710px;
+  flex: 0 0 770px;
   overflow-x: hidden;
   overflow-y: auto;
   height: 100%;
@@ -100,10 +100,10 @@ td {
 
 .type-col { min-width: 150px; width: 150px; }
 .name-col { min-width: 200px; width: 200px; }
-.assignee-col { min-width: 80px; width: 80px; }
-.start-col { min-width: 110px; width: 110px; }
-.end-col { min-width: 110px; width: 110px; }
-.progress-col { min-width: 60px; width: 60px; }
+.assignee-col { min-width: 100px; width: 100px; }
+.start-col { min-width: 120px; width: 120px; }
+.end-col { min-width: 120px; width: 120px; }
+.progress-col { min-width: 80px; width: 80px; }
 
 .day {
   width: 36px;


### PR DESCRIPTION
## Summary
- ガントチャートのタスク情報エリアを770pxに拡大
- 各列幅を見直し進捗率がはみ出ないよう修正

## Testing
- `npm test -- --watch=false` *(Chrome が見つからず失敗)*

------
https://chatgpt.com/codex/tasks/task_e_689ab32a60a88331995b40c0192eedd6