### PR TITLE
ガントチャートの縦スクロール同期の改善

### DIFF
--- a/asobi-fe/asobi-project-fe/src/app/view/parts/gantt-chart/gantt-chart.component.html
+++ b/asobi-fe/asobi-project-fe/src/app/view/parts/gantt-chart/gantt-chart.component.html
@@ -1,5 +1,5 @@
 <div class="gantt-container">
-  <div class="task-area" #taskArea>
+  <div class="task-area">
     <table class="task-table">
       <thead>
         <tr>

--- a/asobi-fe/asobi-project-fe/src/app/view/parts/gantt-chart/gantt-chart.component.scss
+++ b/asobi-fe/asobi-project-fe/src/app/view/parts/gantt-chart/gantt-chart.component.scss
@@ -7,6 +7,8 @@
   display: flex;
   width: 100%;
   height: 100%;
+  overflow-y: auto;
+  overflow-x: hidden;
   border: 1px solid #e5e7eb;
   border-radius: 8px;
   background: #fff;
@@ -14,21 +16,15 @@
 
 .task-area {
   flex: 0 0 770px;
-  overflow-x: hidden;
-  overflow-y: auto;
+  overflow: hidden;
   height: 100%;
   min-height: 300px;
-  scrollbar-width: none;
-  -ms-overflow-style: none;
-}
-
-.task-area::-webkit-scrollbar {
-  display: none;
 }
 
 .chart-area {
   flex: 1;
-  overflow: auto;
+  overflow-x: auto;
+  overflow-y: hidden;
   height: 100%;
   min-height: 300px;
 }

--- a/asobi-fe/asobi-project-fe/src/app/view/parts/gantt-chart/gantt-chart.component.ts
+++ b/asobi-fe/asobi-project-fe/src/app/view/parts/gantt-chart/gantt-chart.component.ts
@@ -22,8 +22,6 @@ import { Task } from '../../../domain/model/task';
 export class GanttChartComponent implements AfterViewInit, OnChanges {
   @Input({ required: true }) tasks: Task[] = [];
   @ViewChild('chartArea') private chartArea?: ElementRef<HTMLDivElement>;
-  @ViewChild('taskArea') private taskArea?: ElementRef<HTMLDivElement>;
-
   protected readonly emptyRows = Array.from({ length: 100 });
   protected dateRange: Date[] = [];
   private rangeStart: Date;
@@ -64,7 +62,7 @@ export class GanttChartComponent implements AfterViewInit, OnChanges {
 
   ngAfterViewInit(): void {
     this.scrollToToday();
-    this.setupScrollSync();
+    this.setupScrollHandling();
   }
 
   ngOnChanges(): void {
@@ -93,22 +91,13 @@ export class GanttChartComponent implements AfterViewInit, OnChanges {
     });
   }
 
-  private setupScrollSync(): void {
-    if (!this.chartArea || !this.taskArea) {
+  private setupScrollHandling(): void {
+    if (!this.chartArea) {
       return;
     }
     const chartEl = this.chartArea.nativeElement;
-    const taskEl = this.taskArea.nativeElement;
 
     chartEl.addEventListener('scroll', () => {
-      const scrollTop = Math.round(chartEl.scrollTop);
-      if (chartEl.scrollTop !== scrollTop) {
-        chartEl.scrollTop = scrollTop;
-      }
-      if (taskEl.scrollTop !== scrollTop) {
-        taskEl.scrollTop = scrollTop;
-      }
-
       if (
         chartEl.scrollLeft + chartEl.clientWidth >=
         chartEl.scrollWidth - 100
@@ -118,16 +107,6 @@ export class GanttChartComponent implements AfterViewInit, OnChanges {
         const prevWidth = chartEl.scrollWidth;
         this.extendLeft(365);
         chartEl.scrollLeft += chartEl.scrollWidth - prevWidth;
-      }
-    });
-
-    taskEl.addEventListener('scroll', () => {
-      const scrollTop = Math.round(taskEl.scrollTop);
-      if (taskEl.scrollTop !== scrollTop) {
-        taskEl.scrollTop = scrollTop;
-      }
-      if (chartEl.scrollTop !== scrollTop) {
-        chartEl.scrollTop = scrollTop;
       }
     });
   }


### PR DESCRIPTION
## 概要
- タスク列と日付列を単一のスクロールコンテナに統合
- スクロール同期処理を整理し水平方向の範囲拡張のみを実装

## テスト
- `npm test -- --watch=false --browsers=ChromeHeadless` (ChromeHeadless が無いため失敗)

------
https://chatgpt.com/codex/tasks/task_e_689ab767091c8331aa11fa7c82af48c9