### PR TITLE
fix: ガントチャートでタスク情報列がスクロールしない問題を修正

### DIFF
--- a/asobi-fe/asobi-project-fe/src/app/view/parts/gantt-chart/gantt-chart.component.html
+++ b/asobi-fe/asobi-project-fe/src/app/view/parts/gantt-chart/gantt-chart.component.html
@@ -1,4 +1,4 @@
-<div class="gantt-container">
+<div class="gantt-container" #ganttContainer>
   <div class="task-area">
     <table class="task-table">
       <thead>

--- a/asobi-fe/asobi-project-fe/src/app/view/parts/gantt-chart/gantt-chart.component.ts
+++ b/asobi-fe/asobi-project-fe/src/app/view/parts/gantt-chart/gantt-chart.component.ts
@@ -22,6 +22,7 @@ import { Task } from '../../../domain/model/task';
 export class GanttChartComponent implements AfterViewInit, OnChanges {
   @Input({ required: true }) tasks: Task[] = [];
   @ViewChild('chartArea') private chartArea?: ElementRef<HTMLDivElement>;
+  @ViewChild('ganttContainer') private ganttContainer?: ElementRef<HTMLDivElement>;
   protected readonly emptyRows = Array.from({ length: 100 });
   protected dateRange: Date[] = [];
   private rangeStart: Date;
@@ -92,10 +93,15 @@ export class GanttChartComponent implements AfterViewInit, OnChanges {
   }
 
   private setupScrollHandling(): void {
-    if (!this.chartArea) {
+    if (!this.chartArea || !this.ganttContainer) {
       return;
     }
     const chartEl = this.chartArea.nativeElement;
+    const containerEl = this.ganttContainer.nativeElement;
+
+    chartEl.addEventListener('wheel', (event) => {
+      containerEl.scrollTop += event.deltaY;
+    });
 
     chartEl.addEventListener('scroll', () => {
       if (


### PR DESCRIPTION
## Summary
- ガントチャートのルート要素に `ganttContainer` 参照を追加
- chart領域でのホイール操作で親コンテナの縦スクロールが動作するよう調整

## Testing
- `npm test -- --watch=false` *(Chromeが無いため失敗)*

------
https://chatgpt.com/codex/tasks/task_e_689abc1b9a3c8331a618e2e9d9dffdb8