### PR TITLE
Fix Gantt chart scroll synchronization

### DIFF
--- a/asobi-fe/asobi-project-fe/src/app/view/parts/gantt-chart/gantt-chart.component.html
+++ b/asobi-fe/asobi-project-fe/src/app/view/parts/gantt-chart/gantt-chart.component.html
@@ -1,5 +1,5 @@
-<div class="gantt-container" #ganttContainer>
-  <div class="task-area">
+<div class="gantt-container">
+  <div class="task-area" #taskArea>
     <table class="task-table">
       <thead>
         <tr>

--- a/asobi-fe/asobi-project-fe/src/app/view/parts/gantt-chart/gantt-chart.component.scss
+++ b/asobi-fe/asobi-project-fe/src/app/view/parts/gantt-chart/gantt-chart.component.scss
@@ -7,8 +7,7 @@
   display: flex;
   width: 100%;
   height: 100%;
-  overflow-y: auto;
-  overflow-x: hidden;
+  overflow: hidden;
   border: 1px solid #e5e7eb;
   border-radius: 8px;
   background: #fff;
@@ -16,15 +15,21 @@
 
 .task-area {
   flex: 0 0 770px;
-  overflow: hidden;
+  overflow-y: auto;
+  overflow-x: hidden;
   height: 100%;
   min-height: 300px;
+  scrollbar-width: none;
+  -ms-overflow-style: none;
+}
+
+.task-area::-webkit-scrollbar {
+  display: none;
 }
 
 .chart-area {
   flex: 1;
-  overflow-x: auto;
-  overflow-y: hidden;
+  overflow: auto;
   height: 100%;
   min-height: 300px;
 }

--- a/asobi-fe/asobi-project-fe/src/app/view/parts/gantt-chart/gantt-chart.component.ts
+++ b/asobi-fe/asobi-project-fe/src/app/view/parts/gantt-chart/gantt-chart.component.ts
@@ -22,7 +22,7 @@ import { Task } from '../../../domain/model/task';
 export class GanttChartComponent implements AfterViewInit, OnChanges {
   @Input({ required: true }) tasks: Task[] = [];
   @ViewChild('chartArea') private chartArea?: ElementRef<HTMLDivElement>;
-  @ViewChild('ganttContainer') private ganttContainer?: ElementRef<HTMLDivElement>;
+  @ViewChild('taskArea') private taskArea?: ElementRef<HTMLDivElement>;
   protected readonly emptyRows = Array.from({ length: 100 });
   protected dateRange: Date[] = [];
   private rangeStart: Date;
@@ -93,17 +93,21 @@ export class GanttChartComponent implements AfterViewInit, OnChanges {
   }
 
   private setupScrollHandling(): void {
-    if (!this.chartArea || !this.ganttContainer) {
+    if (!this.chartArea || !this.taskArea) {
       return;
     }
     const chartEl = this.chartArea.nativeElement;
-    const containerEl = this.ganttContainer.nativeElement;
-
-    chartEl.addEventListener('wheel', (event) => {
-      containerEl.scrollTop += event.deltaY;
-    });
+    const taskEl = this.taskArea.nativeElement;
+    let isSyncing = false;
 
     chartEl.addEventListener('scroll', () => {
+      if (isSyncing) {
+        return;
+      }
+      isSyncing = true;
+      taskEl.scrollTop = chartEl.scrollTop;
+      setTimeout(() => (isSyncing = false));
+
       if (
         chartEl.scrollLeft + chartEl.clientWidth >=
         chartEl.scrollWidth - 100
@@ -114,6 +118,15 @@ export class GanttChartComponent implements AfterViewInit, OnChanges {
         this.extendLeft(365);
         chartEl.scrollLeft += chartEl.scrollWidth - prevWidth;
       }
+    });
+
+    taskEl.addEventListener('scroll', () => {
+      if (isSyncing) {
+        return;
+      }
+      isSyncing = true;
+      chartEl.scrollTop = taskEl.scrollTop;
+      setTimeout(() => (isSyncing = false));
     });
   }
 


### PR DESCRIPTION
## Summary
- 同期スクロール処理を追加してタスク列と日付部分が縦方向に連動するように修正
- スタイルを調整してタスク列を固定しつつ日付部分のみ横スクロール可能に

## Testing
- `npm test` *(Chrome未インストールのため失敗)*

------
https://chatgpt.com/codex/tasks/task_e_689ac38144c4833184b5ad44252cc23d