### PR TITLE
refactor: vertical scroll without sync

### DIFF
--- a/asobi-fe/asobi-project-fe/src/app/view/parts/gantt-chart/gantt-chart.component.html
+++ b/asobi-fe/asobi-project-fe/src/app/view/parts/gantt-chart/gantt-chart.component.html
@@ -1,80 +1,83 @@
 <div class="gantt-container">
-  <div class="task-area" #taskArea>
-    <table class="task-table">
-      <thead>
-        <tr>
-          <th class="type-col">タスク分類</th>
-          <th class="name-col">タスク名</th>
-          <th class="assignee-col">担当者</th>
-          <th class="start-col">開始日</th>
-          <th class="end-col">終了日</th>
-          <th class="progress-col">進捗率</th>
-        </tr>
-      </thead>
-      <tbody>
-        @for (row of emptyRows; track $index; let i = $index) {
+  <div class="body-area">
+    <div class="task-area">
+      <table class="task-table">
+        <thead>
           <tr>
-            @if (tasks[i]; as task) {
-              <td class="type-col">{{ task.type }}</td>
-              <td class="name-col">{{ task.name }}</td>
-              <td class="assignee-col">{{ task.assignee }}</td>
-              <td class="start-col">{{ task.start | date:'yyyy-MM-dd' }}</td>
-              <td class="end-col">{{ task.end | date:'yyyy-MM-dd' }}</td>
-              <td class="progress-col">{{ task.progress }}%</td>
-            } @else {
-              <td class="type-col"></td>
-              <td class="name-col"></td>
-              <td class="assignee-col"></td>
-              <td class="start-col"></td>
-              <td class="end-col"></td>
-              <td class="progress-col"></td>
+            <th class="type-col">タスク分類</th>
+            <th class="name-col">タスク名</th>
+            <th class="assignee-col">担当者</th>
+            <th class="start-col">開始日</th>
+            <th class="end-col">終了日</th>
+            <th class="progress-col">進捗率</th>
+          </tr>
+        </thead>
+        <tbody>
+          @for (row of emptyRows; track $index; let i = $index) {
+            <tr>
+              @if (tasks[i]; as task) {
+                <td class="type-col">{{ task.type }}</td>
+                <td class="name-col">{{ task.name }}</td>
+                <td class="assignee-col">{{ task.assignee }}</td>
+                <td class="start-col">{{ task.start | date: "yyyy-MM-dd" }}</td>
+                <td class="end-col">{{ task.end | date: "yyyy-MM-dd" }}</td>
+                <td class="progress-col">{{ task.progress }}%</td>
+              } @else {
+                <td class="type-col"></td>
+                <td class="name-col"></td>
+                <td class="assignee-col"></td>
+                <td class="start-col"></td>
+                <td class="end-col"></td>
+                <td class="progress-col"></td>
+              }
+            </tr>
+          }
+        </tbody>
+      </table>
+    </div>
+    <div class="chart-area" #chartArea>
+      <table class="chart-table">
+        <thead>
+          <tr>
+            @for (month of months; track month.label) {
+              <th [attr.colspan]="month.days">{{ month.label }}</th>
             }
           </tr>
-        }
-      </tbody>
-    </table>
-  </div>
-  <div class="chart-area" #chartArea>
-    <table class="chart-table">
-      <thead>
-        <tr>
-          @for (month of months; track month.label) {
-            <th [attr.colspan]="month.days">{{ month.label }}</th>
-          }
-        </tr>
-        <tr>
-          @for (date of dateRange; track $index; let i = $index) {
-            <th
-              class="date-col"
-              [class.month-boundary]="isMonthStart(date) && i !== 0"
-              >{{ date | date:'dd' }}</th
-            >
-          }
-        </tr>
-      </thead>
-      <tbody>
-        @for (row of emptyRows; track $index; let i = $index) {
           <tr>
-            @if (tasks[i]; as task) {
-              @for (date of dateRange; track $index; let j = $index) {
-                <td
-                  class="day"
-                  [class.progress]="isProgress(task, date)"
-                  [class.planned]="isPlanned(task, date)"
-                  [class.month-boundary]="isMonthStart(date) && j !== 0"
-                ></td>
-              }
-            } @else {
-              @for (date of dateRange; track $index; let j = $index) {
-                <td
-                  class="day"
-                  [class.month-boundary]="isMonthStart(date) && j !== 0"
-                ></td>
-              }
+            @for (date of dateRange; track $index; let i = $index) {
+              <th
+                class="date-col"
+                [class.month-boundary]="isMonthStart(date) && i !== 0"
+              >
+                {{ date | date: "dd" }}
+              </th>
             }
           </tr>
-        }
-      </tbody>
-    </table>
+        </thead>
+        <tbody>
+          @for (row of emptyRows; track $index; let i = $index) {
+            <tr>
+              @if (tasks[i]; as task) {
+                @for (date of dateRange; track $index; let j = $index) {
+                  <td
+                    class="day"
+                    [class.progress]="isProgress(task, date)"
+                    [class.planned]="isPlanned(task, date)"
+                    [class.month-boundary]="isMonthStart(date) && j !== 0"
+                  ></td>
+                }
+              } @else {
+                @for (date of dateRange; track $index; let j = $index) {
+                  <td
+                    class="day"
+                    [class.month-boundary]="isMonthStart(date) && j !== 0"
+                  ></td>
+                }
+              }
+            </tr>
+          }
+        </tbody>
+      </table>
+    </div>
   </div>
 </div>

--- a/asobi-fe/asobi-project-fe/src/app/view/parts/gantt-chart/gantt-chart.component.scss
+++ b/asobi-fe/asobi-project-fe/src/app/view/parts/gantt-chart/gantt-chart.component.scss
@@ -13,25 +13,33 @@
   background: #fff;
 }
 
-.task-area {
-  flex: 0 0 770px;
+.body-area {
+  display: flex;
+  width: 100%;
+  height: 100%;
   overflow-y: auto;
   overflow-x: hidden;
-  height: 100%;
-  min-height: 300px;
   scrollbar-width: none;
   -ms-overflow-style: none;
 }
 
-.task-area::-webkit-scrollbar {
+.body-area::-webkit-scrollbar {
   display: none;
+}
+
+.task-area {
+  flex: 0 0 770px;
+  height: 100%;
+  min-height: 300px;
+  overflow: hidden;
 }
 
 .chart-area {
   flex: 1;
-  overflow: auto;
   height: 100%;
   min-height: 300px;
+  overflow-x: auto;
+  overflow-y: hidden;
 }
 
 .task-table,
@@ -99,12 +107,30 @@ td {
   padding: 0 4px;
 }
 
-.type-col { min-width: 150px; width: 150px; }
-.name-col { min-width: 200px; width: 200px; }
-.assignee-col { min-width: 80px; width: 80px; }
-.start-col { min-width: 100px; width: 100px; }
-.end-col { min-width: 100px; width: 100px; }
-.progress-col { min-width: 80px; width: 80px; }
+.type-col {
+  min-width: 150px;
+  width: 150px;
+}
+.name-col {
+  min-width: 200px;
+  width: 200px;
+}
+.assignee-col {
+  min-width: 80px;
+  width: 80px;
+}
+.start-col {
+  min-width: 100px;
+  width: 100px;
+}
+.end-col {
+  min-width: 100px;
+  width: 100px;
+}
+.progress-col {
+  min-width: 80px;
+  width: 80px;
+}
 
 .day {
   width: 36px;
@@ -128,5 +154,3 @@ td {
 .chart-table tbody tr:nth-child(even) {
   background: #f5f5f5;
 }
-
-

--- a/asobi-fe/asobi-project-fe/src/app/view/parts/gantt-chart/gantt-chart.component.ts
+++ b/asobi-fe/asobi-project-fe/src/app/view/parts/gantt-chart/gantt-chart.component.ts
@@ -22,7 +22,6 @@ import { Task } from '../../../domain/model/task';
 export class GanttChartComponent implements AfterViewInit, OnChanges {
   @Input({ required: true }) tasks: Task[] = [];
   @ViewChild('chartArea') private chartArea?: ElementRef<HTMLDivElement>;
-  @ViewChild('taskArea') private taskArea?: ElementRef<HTMLDivElement>;
   protected readonly emptyRows = Array.from({ length: 100 });
   protected dateRange: Date[] = [];
   private rangeStart: Date;
@@ -63,7 +62,7 @@ export class GanttChartComponent implements AfterViewInit, OnChanges {
 
   ngAfterViewInit(): void {
     this.scrollToToday();
-    this.setupScrollHandling();
+    this.setupChartScrollHandling();
   }
 
   ngOnChanges(): void {
@@ -76,9 +75,7 @@ export class GanttChartComponent implements AfterViewInit, OnChanges {
       return;
     }
     const today = this.getToday();
-    const index = this.dateRange.findIndex((d) =>
-      this.isSameDay(d, today),
-    );
+    const index = this.dateRange.findIndex((d) => this.isSameDay(d, today));
     if (index < 0) {
       return;
     }
@@ -92,22 +89,12 @@ export class GanttChartComponent implements AfterViewInit, OnChanges {
     });
   }
 
-  private setupScrollHandling(): void {
-    if (!this.chartArea || !this.taskArea) {
+  private setupChartScrollHandling(): void {
+    if (!this.chartArea) {
       return;
     }
     const chartEl = this.chartArea.nativeElement;
-    const taskEl = this.taskArea.nativeElement;
-    let isSyncing = false;
-
     chartEl.addEventListener('scroll', () => {
-      if (isSyncing) {
-        return;
-      }
-      isSyncing = true;
-      taskEl.scrollTop = chartEl.scrollTop;
-      setTimeout(() => (isSyncing = false));
-
       if (
         chartEl.scrollLeft + chartEl.clientWidth >=
         chartEl.scrollWidth - 100
@@ -118,15 +105,6 @@ export class GanttChartComponent implements AfterViewInit, OnChanges {
         this.extendLeft(365);
         chartEl.scrollLeft += chartEl.scrollWidth - prevWidth;
       }
-    });
-
-    taskEl.addEventListener('scroll', () => {
-      if (isSyncing) {
-        return;
-      }
-      isSyncing = true;
-      chartEl.scrollTop = taskEl.scrollTop;
-      setTimeout(() => (isSyncing = false));
     });
   }
 


### PR DESCRIPTION
## Summary
- タスク情報と日付表示を一体でスクロールするようレイアウトを刷新
- スクロール同期用の処理を削除し、横スクロールのみに限定

## Testing
- `npm test -- --watch=false --browsers=ChromeHeadless` *(fails: No binary for ChromeHeadless browser)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689ac8dc64508331bf4c1524c1e948e7