### PR TITLE
フッターのデザインをヘッダーと統一

### DIFF
--- a/asobi-fe/asobi-project-fe/public/clock.svg
+++ b/asobi-fe/asobi-project-fe/public/clock.svg
@@ -1,0 +1,4 @@
+<svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" fill="none" stroke="#fff" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <circle cx="12" cy="12" r="10"/>
+  <polyline points="12 6 12 12 16 14"/>
+</svg>

--- a/asobi-fe/asobi-project-fe/src/app/view/parts/footer/footer.component.html
+++ b/asobi-fe/asobi-project-fe/src/app/view/parts/footer/footer.component.html
@@ -1,3 +1,4 @@
 <footer class="footer">
+  <img src="clock.svg" alt="" class="icon" />
   <span>{{ dateTime }}</span>
 </footer>

--- a/asobi-fe/asobi-project-fe/src/app/view/parts/footer/footer.component.scss
+++ b/asobi-fe/asobi-project-fe/src/app/view/parts/footer/footer.component.scss
@@ -1,6 +1,15 @@
 .footer {
-  background: #000;
+  background: linear-gradient(90deg, #1f2937, #111827);
   color: #fff;
-  text-align: right;
+  display: flex;
+  justify-content: flex-end;
+  align-items: center;
+  gap: 0.5rem;
   padding: 0.5rem 1rem;
+  font-weight: 600;
+}
+
+.icon {
+  width: 24px;
+  height: 24px;
 }


### PR DESCRIPTION
## 概要
- フッターに時計アイコンを追加し、ヘッダーと同様のグラデーション・フォントに調整

## テスト
- `npm test` (Chromeのバイナリが見つからず失敗)

------
https://chatgpt.com/codex/tasks/task_e_689acb6273448331927c534848d925c7