### PR TITLE
ガントチャートヘッダーの色を調整

### DIFF
--- a/asobi-fe/asobi-project-fe/src/app/view/parts/gantt-chart/gantt-chart.component.scss
+++ b/asobi-fe/asobi-project-fe/src/app/view/parts/gantt-chart/gantt-chart.component.scss
@@ -79,7 +79,7 @@ td {
 .chart-table thead th {
   position: sticky;
   top: 0;
-  background: #f3f4f6;
+  background: #e0f2fe;
   z-index: 1;
 }
 


### PR DESCRIPTION
## Summary
- ツールバーとガントチャートのヘッダーの色が同じで分かりにくかったため、ヘッダーの背景色をテーマに沿った淡い水色に変更

## Testing
- `npm test -- --watch=false --browsers=ChromeHeadless` *(ChromeHeadlessのバイナリが見つからずテスト未実行)*

------
https://chatgpt.com/codex/tasks/task_e_689acea9c9f88331b268bcc30e6052cf