### PR TITLE
fix: ガントチャートの日付ヘッダーを固定

### DIFF
--- a/asobi-fe/asobi-project-fe/src/app/view/parts/gantt-chart/gantt-chart.component.scss
+++ b/asobi-fe/asobi-project-fe/src/app/view/parts/gantt-chart/gantt-chart.component.scss
@@ -37,6 +37,7 @@
   flex: 1;
   min-height: 300px;
   overflow-x: auto;
+  overflow-y: hidden;
 }
 
 .task-table,


### PR DESCRIPTION
## 概要
- ガントチャートで縦スクロール時に月日ヘッダーがスクロールされてしまう問題を修正

## テスト
- `npm test` (Chrome が見つからず失敗)


------
https://chatgpt.com/codex/tasks/task_e_689ace375e848331a0e361cf9eff248a