### PR TITLE
fix: adjust today column scroll

### DIFF
--- a/asobi-fe/asobi-project-fe/src/app/view/parts/gantt-chart/gantt-chart.component.ts
+++ b/asobi-fe/asobi-project-fe/src/app/view/parts/gantt-chart/gantt-chart.component.ts
@@ -92,7 +92,14 @@ export class GanttChartComponent implements AfterViewInit, OnChanges {
 
     requestAnimationFrame(() => {
       const th = host.querySelector<HTMLElement>(`.head-2 th[data-idx="${idx}"]`);
-      if (th) host.scrollLeft = th.offsetLeft;
+      const stickyCols = host.querySelectorAll<HTMLElement>(
+        '.head-1 .sticky-left'
+      );
+      const stickyWidth = Array.from(stickyCols).reduce(
+        (sum, el) => sum + el.offsetWidth,
+        0
+      );
+      if (th) host.scrollLeft = Math.max(th.offsetLeft - stickyWidth, 0);
     });
   }
 


### PR DESCRIPTION
## Summary
- 今日に戻るボタンと初期表示で、今日の日付列がタスク情報のすぐ右に表示されるようスクロール位置を調整

## Testing
- `npm test` *(Chrome が見つからないため失敗)*

------
https://chatgpt.com/codex/tasks/task_e_689ae3fdd6d883318c54861c1ccd7020