### PR TITLE
feat: jump to selected date via calendar modal

### DIFF
--- a/asobi-fe/asobi-project-fe/public/calendar.svg
+++ b/asobi-fe/asobi-project-fe/public/calendar.svg
@@ -1,0 +1,6 @@
+<svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" fill="none" stroke="#fff" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <rect x="3" y="4" width="18" height="18" rx="2" ry="2"/>
+  <line x1="16" y1="2" x2="16" y2="6"/>
+  <line x1="8" y1="2" x2="8" y2="6"/>
+  <line x1="3" y1="10" x2="21" y2="10"/>
+</svg>

--- a/asobi-fe/asobi-project-fe/src/app/page/schedule/schedule-page.component.html
+++ b/asobi-fe/asobi-project-fe/src/app/page/schedule/schedule-page.component.html
@@ -1,7 +1,10 @@
 <app-schedule-layout
   [tasks]="tasks()"
   [formVisible]="isFormVisible()"
+  [calendarVisible]="isCalendarVisible()"
   [dateTime]="dateTime()"
   (openForm)="openForm()"
   (closeForm)="closeForm()"
+  (openCalendar)="openCalendar()"
+  (closeCalendar)="closeCalendar()"
   (create)="onCreate($event)"></app-schedule-layout>

--- a/asobi-fe/asobi-project-fe/src/app/page/schedule/schedule-page.component.ts
+++ b/asobi-fe/asobi-project-fe/src/app/page/schedule/schedule-page.component.ts
@@ -16,6 +16,7 @@ export class SchedulePageComponent implements OnInit {
   #clockService = inject(ClockService);
   protected tasks = this.#scheduleService.tasks;
   protected isFormVisible = signal(false);
+  protected isCalendarVisible = signal(false);
   protected dateTime = this.#clockService.now;
 
   ngOnInit(): void {
@@ -29,6 +30,14 @@ export class SchedulePageComponent implements OnInit {
 
   closeForm(): void {
     this.isFormVisible.set(false);
+  }
+
+  openCalendar(): void {
+    this.isCalendarVisible.set(true);
+  }
+
+  closeCalendar(): void {
+    this.isCalendarVisible.set(false);
   }
 
   onCreate(task: Task): void {

--- a/asobi-fe/asobi-project-fe/src/app/view/layouts/schedule-layout/schedule-layout.component.html
+++ b/asobi-fe/asobi-project-fe/src/app/view/layouts/schedule-layout/schedule-layout.component.html
@@ -6,12 +6,17 @@
         <img src="add.svg" alt="" class="icon" />
         タスクを追加
       </button>
-      <button class="to-today secondary" (click)="ganttChart.scrollToToday()">
-        <img src="today.svg" alt="" class="icon" />
-        今日に戻る
+      <button class="open-calendar secondary" (click)="openCalendar.emit()">
+        <img src="calendar.svg" alt="カレンダーを開く" class="icon" />
       </button>
     </div>
     <app-gantt-chart #ganttChart [tasks]="tasks"></app-gantt-chart>
+    @if (calendarVisible) {
+      <app-calendar-modal
+        (confirm)="onCalendarConfirm($event)"
+        (close)="closeCalendar.emit()"
+      ></app-calendar-modal>
+    }
     @if (formVisible) {
       <div class="task-dialog" (click)="closeForm.emit()">
         <div class="dialog" (click)="$event.stopPropagation()">

--- a/asobi-fe/asobi-project-fe/src/app/view/layouts/schedule-layout/schedule-layout.component.ts
+++ b/asobi-fe/asobi-project-fe/src/app/view/layouts/schedule-layout/schedule-layout.component.ts
@@ -1,23 +1,34 @@
-import { ChangeDetectionStrategy, Component, EventEmitter, Input, Output } from '@angular/core';
+import { ChangeDetectionStrategy, Component, EventEmitter, Input, Output, ViewChild } from '@angular/core';
 import { Task } from '../../../domain/model/task';
 import { GanttChartComponent } from '../../parts/gantt-chart/gantt-chart.component';
 import { TaskFormComponent } from '../../parts/task-form/task-form.component';
 import { HeaderComponent } from '../../parts/header/header.component';
 import { FooterComponent } from '../../parts/footer/footer.component';
+import { CalendarModalComponent } from '../../parts/calendar-modal/calendar-modal.component';
 
 @Component({
   selector: 'app-schedule-layout',
   standalone: true,
-  imports: [HeaderComponent, GanttChartComponent, TaskFormComponent, FooterComponent],
+  imports: [HeaderComponent, GanttChartComponent, TaskFormComponent, FooterComponent, CalendarModalComponent],
   changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: './schedule-layout.component.html',
   styleUrl: './schedule-layout.component.scss'
 })
 export class ScheduleLayoutComponent {
+  @ViewChild('ganttChart') private ganttChart?: GanttChartComponent;
+
   @Input({ required: true }) tasks: Task[] = [];
   @Input() formVisible = false;
   @Input() dateTime = '';
+  @Input() calendarVisible = false;
   @Output() create = new EventEmitter<Task>();
   @Output() openForm = new EventEmitter<void>();
   @Output() closeForm = new EventEmitter<void>();
+  @Output() openCalendar = new EventEmitter<void>();
+  @Output() closeCalendar = new EventEmitter<void>();
+
+  onCalendarConfirm(date: Date): void {
+    this.ganttChart?.scrollToDate(date);
+    this.closeCalendar.emit();
+  }
 }

--- a/asobi-fe/asobi-project-fe/src/app/view/parts/calendar-modal/calendar-modal.component.html
+++ b/asobi-fe/asobi-project-fe/src/app/view/parts/calendar-modal/calendar-modal.component.html
@@ -1,0 +1,9 @@
+<div class="calendar-modal" (click)="close.emit()">
+  <div class="dialog" (click)="$event.stopPropagation()">
+    <h2>日付選択</h2>
+    <input type="date" [(ngModel)]="selected" />
+    <div class="actions">
+      <button class="confirm" (click)="submit()">決定</button>
+    </div>
+  </div>
+</div>

--- a/asobi-fe/asobi-project-fe/src/app/view/parts/calendar-modal/calendar-modal.component.scss
+++ b/asobi-fe/asobi-project-fe/src/app/view/parts/calendar-modal/calendar-modal.component.scss
@@ -1,0 +1,36 @@
+.calendar-modal {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.4);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+}
+
+.calendar-modal .dialog {
+  background: #fff;
+  padding: 1.5rem;
+  border-radius: 8px;
+  width: 280px;
+  max-width: 90%;
+  box-shadow: 0 2px 10px rgba(0, 0, 0, 0.2);
+}
+
+.calendar-modal .actions {
+  text-align: right;
+  margin-top: 1rem;
+}
+
+.calendar-modal button {
+  background: var(--color-primary);
+  border: none;
+  color: #fff;
+  padding: 0.4rem 0.8rem;
+  border-radius: 6px;
+  cursor: pointer;
+}
+
+.calendar-modal button:hover {
+  background: #2563eb;
+}

--- a/asobi-fe/asobi-project-fe/src/app/view/parts/calendar-modal/calendar-modal.component.ts
+++ b/asobi-fe/asobi-project-fe/src/app/view/parts/calendar-modal/calendar-modal.component.ts
@@ -1,0 +1,26 @@
+import { ChangeDetectionStrategy, Component, EventEmitter, Output } from '@angular/core';
+import { FormsModule } from '@angular/forms';
+
+@Component({
+  selector: 'app-calendar-modal',
+  standalone: true,
+  imports: [FormsModule],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  templateUrl: './calendar-modal.component.html',
+  styleUrl: './calendar-modal.component.scss'
+})
+export class CalendarModalComponent {
+  protected selected = this.toInputValue(new Date());
+
+  @Output() confirm = new EventEmitter<Date>();
+  @Output() close = new EventEmitter<void>();
+
+  protected submit(): void {
+    this.confirm.emit(new Date(this.selected));
+  }
+
+  private toInputValue(date: Date): string {
+    return date.toISOString().split('T')[0];
+  }
+}
+

--- a/asobi-fe/asobi-project-fe/src/app/view/parts/gantt-chart/gantt-chart.component.ts
+++ b/asobi-fe/asobi-project-fe/src/app/view/parts/gantt-chart/gantt-chart.component.ts
@@ -82,12 +82,15 @@ export class GanttChartComponent implements AfterViewInit, OnChanges {
     this.scrollToToday();
   }
 
-  private scrollToToday(): void {
+  public scrollToDate(date: Date): void {
     const host = this.scrollHost?.nativeElement;
     if (!host) return;
 
-    const today = this.getToday();
-    const idx = this.dateRange.findIndex((d) => this.isSameDay(d, today));
+    const target = this.toStartOfDay(date);
+    while (target < this.rangeStart) this.extendLeft(365);
+    while (target > this.rangeEnd) this.extendRight(365);
+
+    const idx = this.dateRange.findIndex((d) => this.isSameDay(d, target));
     if (idx < 0) return;
 
     requestAnimationFrame(() => {
@@ -101,6 +104,10 @@ export class GanttChartComponent implements AfterViewInit, OnChanges {
       );
       if (th) host.scrollLeft = Math.max(th.offsetLeft - stickyWidth, 0);
     });
+  }
+
+  public scrollToToday(): void {
+    this.scrollToDate(this.getToday());
   }
 
   private setupScrollHandling(): void {


### PR DESCRIPTION
## Summary
- replace "今日に戻る" button with calendar icon opening calendar modal
- allow selecting date to scroll Gantt chart to that column
- expose scrollToDate API on Gantt chart and add calendar modal component

## Testing
- `npm test` *(fails: No binary for Chrome browser on your platform)*

------
https://chatgpt.com/codex/tasks/task_e_689aeaf00b48833183d15323c131a1a4