### PR TITLE
ガントチャートの偶数行塗りつぶし不具合を修正

### DIFF
--- a/asobi-fe/asobi-project-fe/src/app/view/parts/gantt-chart/gantt-chart.component.scss
+++ b/asobi-fe/asobi-project-fe/src/app/view/parts/gantt-chart/gantt-chart.component.scss
@@ -115,10 +115,6 @@ thead .sticky-left.h {
 .date-col { width: 36px; text-align: center; }
 .day      { width: 36px; padding: 0; }
 
-/* 塗りつぶし */
-.day.progress { background-color: var(--color-primary, #60a5fa); }
-.day.planned  { background-color: #93c5fd; }
-
 /* 月境界の強線 */
 .month-boundary { border-left: 2px solid #9ca3af !important; }
 
@@ -126,3 +122,7 @@ thead .sticky-left.h {
 .gantt-table tbody tr:nth-child(even) td:not(.sticky-left) {
   background: #f5f5f5;
 }
+
+/* 塗りつぶし */
+.gantt-table tbody tr td.day.progress { background-color: var(--color-primary, #60a5fa); }
+.gantt-table tbody tr td.day.planned  { background-color: #93c5fd; }


### PR DESCRIPTION
## 概要
- 偶数行の背景色指定がタスク期間の塗りつぶしを上書きしていたため、CSS のセレクタ順序と優先度を見直し、タスク期間が正しく表示されるよう修正

## テスト
- `npm test -- --watch=false` (Chrome が見つからず失敗)

------
https://chatgpt.com/codex/tasks/task_e_689aed71e1dc83318591fc493ae19205