### PR TITLE
カレンダーのモーダルを常時表示に変更

### DIFF
--- a/asobi-fe/asobi-project-fe/src/app/view/parts/calendar-modal/calendar-modal.component.html
+++ b/asobi-fe/asobi-project-fe/src/app/view/parts/calendar-modal/calendar-modal.component.html
@@ -1,7 +1,37 @@
 <div class="calendar-modal" (click)="close.emit()">
   <div class="dialog" (click)="$event.stopPropagation()">
     <h2>日付選択</h2>
-    <input type="date" [(ngModel)]="selected" />
+    <div class="calendar">
+      <div class="header">
+        <button class="nav" (click)="prevMonth()">&#x2039;</button>
+        <span class="title">{{ displayDate | date: 'y年M月' }}</span>
+        <button class="nav" (click)="nextMonth()">&#x203A;</button>
+      </div>
+      <table>
+        <thead>
+          <tr>
+            @for (day of ['日', '月', '火', '水', '木', '金', '土']; track day) {
+              <th>{{ day }}</th>
+            }
+          </tr>
+        </thead>
+        <tbody>
+          @for (week of weeks; track $index) {
+            <tr>
+              @for (day of week; track day.getTime()) {
+                <td
+                  (click)="select(day)"
+                  [class.other-month]="!isCurrentMonth(day)"
+                  [class.selected]="isSelected(day)"
+                >
+                  {{ day.getDate() }}
+                </td>
+              }
+            </tr>
+          }
+        </tbody>
+      </table>
+    </div>
     <div class="actions">
       <button class="confirm" (click)="submit()">決定</button>
     </div>

--- a/asobi-fe/asobi-project-fe/src/app/view/parts/calendar-modal/calendar-modal.component.scss
+++ b/asobi-fe/asobi-project-fe/src/app/view/parts/calendar-modal/calendar-modal.component.scss
@@ -21,8 +21,8 @@
   text-align: right;
   margin-top: 1rem;
 }
-
-.calendar-modal button {
+ 
+.calendar-modal .actions .confirm {
   background: var(--color-primary);
   border: none;
   color: #fff;
@@ -31,6 +31,50 @@
   cursor: pointer;
 }
 
-.calendar-modal button:hover {
+.calendar-modal .actions .confirm:hover {
   background: #2563eb;
+}
+
+.calendar {
+  margin-top: 1rem;
+}
+
+.calendar .header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 0.5rem;
+}
+
+.calendar .nav {
+  background: none;
+  border: none;
+  cursor: pointer;
+  padding: 0.2rem 0.4rem;
+}
+
+.calendar table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+.calendar th,
+.calendar td {
+  width: 14.285%;
+  text-align: center;
+  padding: 0.3rem 0;
+}
+
+.calendar td {
+  cursor: pointer;
+}
+
+.calendar td.other-month {
+  color: #aaa;
+}
+
+.calendar td.selected {
+  background: var(--color-primary);
+  color: #fff;
+  border-radius: 50%;
 }

--- a/asobi-fe/asobi-project-fe/src/app/view/parts/calendar-modal/calendar-modal.component.ts
+++ b/asobi-fe/asobi-project-fe/src/app/view/parts/calendar-modal/calendar-modal.component.ts
@@ -1,26 +1,82 @@
-import { ChangeDetectionStrategy, Component, EventEmitter, Output } from '@angular/core';
-import { FormsModule } from '@angular/forms';
+import {
+  ChangeDetectionStrategy,
+  Component,
+  EventEmitter,
+  Output
+} from '@angular/core';
+import { CommonModule, DatePipe } from '@angular/common';
 
 @Component({
   selector: 'app-calendar-modal',
   standalone: true,
-  imports: [FormsModule],
+  imports: [CommonModule, DatePipe],
   changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: './calendar-modal.component.html',
   styleUrl: './calendar-modal.component.scss'
 })
 export class CalendarModalComponent {
-  protected selected = this.toInputValue(new Date());
+  protected displayDate = new Date();
+  protected selectedDate = new Date();
+  protected weeks: Date[][] = [];
 
   @Output() confirm = new EventEmitter<Date>();
   @Output() close = new EventEmitter<void>();
 
-  protected submit(): void {
-    this.confirm.emit(new Date(this.selected));
+  constructor() {
+    this.generateCalendar();
   }
 
-  private toInputValue(date: Date): string {
-    return date.toISOString().split('T')[0];
+  protected prevMonth(): void {
+    this.displayDate = new Date(
+      this.displayDate.getFullYear(),
+      this.displayDate.getMonth() - 1,
+      1
+    );
+    this.generateCalendar();
+  }
+
+  protected nextMonth(): void {
+    this.displayDate = new Date(
+      this.displayDate.getFullYear(),
+      this.displayDate.getMonth() + 1,
+      1
+    );
+    this.generateCalendar();
+  }
+
+  protected select(day: Date): void {
+    this.selectedDate = day;
+  }
+
+  protected isCurrentMonth(day: Date): boolean {
+    return day.getMonth() === this.displayDate.getMonth();
+  }
+
+  protected isSelected(day: Date): boolean {
+    return day.toDateString() === this.selectedDate.toDateString();
+  }
+
+  protected submit(): void {
+    this.confirm.emit(new Date(this.selectedDate));
+  }
+
+  private generateCalendar(): void {
+    const first = new Date(
+      this.displayDate.getFullYear(),
+      this.displayDate.getMonth(),
+      1
+    );
+    const start = new Date(first);
+    start.setDate(first.getDate() - first.getDay());
+    this.weeks = [];
+    for (let i = 0; i < 6; i++) {
+      const week: Date[] = [];
+      for (let j = 0; j < 7; j++) {
+        week.push(new Date(start));
+        start.setDate(start.getDate() + 1);
+      }
+      this.weeks.push(week);
+    }
   }
 }
 


### PR DESCRIPTION
## 概要
- モーダル内にカレンダーを直接表示し、ヘッダーの矢印で前後月を切り替え可能に変更
- 日付セルの選択状態をハイライトするスタイルを追加

## テスト
- `npm test -- --watch=false` (Chrome のバイナリが無いため失敗)


------
https://chatgpt.com/codex/tasks/task_e_689aee0363248331a85666857f5cf13b