### PR TITLE
feat: improve calendar modal design

### DIFF
--- a/asobi-fe/asobi-project-fe/src/app/view/parts/calendar-modal/calendar-modal.component.html
+++ b/asobi-fe/asobi-project-fe/src/app/view/parts/calendar-modal/calendar-modal.component.html
@@ -3,9 +3,23 @@
     <h2>日付選択</h2>
     <div class="calendar">
       <div class="header">
-        <button class="nav" (click)="prevMonth()">&#x2039;</button>
+        <button
+          class="nav"
+          type="button"
+          aria-label="前の月へ"
+          (click)="prevMonth()"
+        >
+          &#x2039;
+        </button>
         <span class="title">{{ displayDate | date: 'y年M月' }}</span>
-        <button class="nav" (click)="nextMonth()">&#x203A;</button>
+        <button
+          class="nav"
+          type="button"
+          aria-label="次の月へ"
+          (click)="nextMonth()"
+        >
+          &#x203A;
+        </button>
       </div>
       <table>
         <thead>

--- a/asobi-fe/asobi-project-fe/src/app/view/parts/calendar-modal/calendar-modal.component.scss
+++ b/asobi-fe/asobi-project-fe/src/app/view/parts/calendar-modal/calendar-modal.component.scss
@@ -1,7 +1,8 @@
 .calendar-modal {
   position: fixed;
   inset: 0;
-  background: rgba(0, 0, 0, 0.4);
+  background: rgba(0, 0, 0, 0.6);
+  backdrop-filter: blur(2px);
   display: flex;
   align-items: center;
   justify-content: center;
@@ -50,7 +51,20 @@
   background: none;
   border: none;
   cursor: pointer;
-  padding: 0.2rem 0.4rem;
+  padding: 0.2rem;
+  color: var(--color-primary);
+  border-radius: 50%;
+  width: 32px;
+  height: 32px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 1.2rem;
+  transition: background-color 0.2s;
+}
+
+.calendar .nav:hover {
+  background: rgba(59, 130, 246, 0.1);
 }
 
 .calendar table {


### PR DESCRIPTION
## Summary
- make calendar modal overlay darker with blur effect
- restyle navigation arrows with accent color and hover feedback
- add accessible labels for month navigation buttons

## Testing
- `npm test -- --watch=false --browsers=ChromeHeadless` *(fails: No binary for ChromeHeadless browser on your platform. Please, set "CHROME_BIN" env variable.)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_689af0942a608331a265972609afebd9