### PR TITLE
モダンなガントチャートのデザイン刷新

### DIFF
--- a/asobi-fe/asobi-project-fe/src/app/view/layouts/schedule-layout/schedule-layout.component.scss
+++ b/asobi-fe/asobi-project-fe/src/app/view/layouts/schedule-layout/schedule-layout.component.scss
@@ -17,6 +17,8 @@
   justify-content: flex-end;
   gap: 0.5rem;
   padding: 0.5rem 1rem;
+  background: var(--color-surface);
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.05);
 }
 
 .toolbar button {

--- a/asobi-fe/asobi-project-fe/src/app/view/parts/gantt-chart/gantt-chart.component.html
+++ b/asobi-fe/asobi-project-fe/src/app/view/parts/gantt-chart/gantt-chart.component.html
@@ -47,6 +47,10 @@
                   class="day"
                   [class.progress]="isProgress(task, date)"
                   [class.planned]="isPlanned(task, date)"
+                  [class.progress-start]="isProgressStart(task, date)"
+                  [class.progress-end]="isProgressEnd(task, date)"
+                  [class.planned-start]="isPlannedStart(task, date)"
+                  [class.planned-end]="isPlannedEnd(task, date)"
                   [class.month-boundary]="isMonthStart(date) && j !== 0"
                 ></td>
               }

--- a/asobi-fe/asobi-project-fe/src/app/view/parts/gantt-chart/gantt-chart.component.scss
+++ b/asobi-fe/asobi-project-fe/src/app/view/parts/gantt-chart/gantt-chart.component.scss
@@ -25,9 +25,9 @@
 
 .gantt-container {
   height: 100%;
-  border: 1px solid #e5e7eb;
   border-radius: 8px;
-  background: #fff;
+  background: var(--color-surface);
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
 }
 
 /* sticky の基準を1つに限定 */
@@ -48,7 +48,7 @@
 
 .gantt-table th,
 .gantt-table td {
-  border: 1px solid #e5e7eb;
+  border: none;
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -57,9 +57,9 @@
 /* ---------------- ヘッダー固定（2行） ---------------- */
 .gantt-table thead .h {
   position: sticky;
-  background: #e0f2fe;
-  color: #111827;
-  padding: 0 4px;
+  background: linear-gradient(135deg, #93c5fd, #3b82f6);
+  color: #fff;
+  padding: 0 6px;
   z-index: 10; /* 基本層 */
 }
 
@@ -85,14 +85,15 @@
 /* 左6列のヘッダー（rowspan=2）は最前面＆ヘッダー色を維持 */
 thead .sticky-left.h {
   z-index: 100 !important;         /* ボディより上に確実に */
-  background: #e0f2fe !important;  /* ヘッダー色を優先 */
+  background: linear-gradient(135deg, #93c5fd, #3b82f6) !important;  /* ヘッダー色を優先 */
 }
 
 /* 左固定列（ヘッダー/ボディ共通） */
 .sticky-left {
   position: sticky;
-  background: #fff;   /* ボディ側は白（ヘッダーは上で上書き） */
+  background: var(--color-surface);   /* ボディ側は白（ヘッダーは上で上書き） */
   z-index: 20;        /* ボディ左列の基準層 */
+  border-right: 1px solid #e5e7eb;
 }
 
 /* 列幅と固定位置 */
@@ -104,25 +105,44 @@ thead .sticky-left.h {
 .col-progress { min-width: var(--w-progress); width: var(--w-progress); left: var(--left-progress); }
 
 /* ---------------- ボディ行 ---------------- */
-.gantt-table tbody tr { height: var(--row-h); }
+.gantt-table tbody tr {
+  height: var(--row-h);
+  transition: background-color 0.2s;
+}
 .gantt-table tbody td {
   height: var(--row-h);
   line-height: var(--row-h);
   padding: 0 4px;
+  border-bottom: 1px solid #e5e7eb;
+}
+
+.gantt-table tbody tr:hover td:not(.sticky-left) {
+  background: #f3f4f6;
 }
 
 /* 日付列のヘッダー/ボディ幅 */
 .date-col { width: 36px; text-align: center; }
-.day      { width: 36px; padding: 0; }
+.day      { width: 36px; padding: 0; position: relative; }
+
+.day::before {
+  content: '';
+  position: absolute;
+  top: 20%;
+  bottom: 20%;
+  left: 2px;
+  right: 2px;
+  border-radius: 4px;
+  background: transparent;
+}
+
+.day.progress::before { background-color: var(--color-primary, #3b82f6); }
+.day.planned::before  { background-color: rgba(59, 130, 246, 0.3); }
+
+.day.progress-start::before { border-top-left-radius: 10px; border-bottom-left-radius: 10px; }
+.day.progress-end::before   { border-top-right-radius: 10px; border-bottom-right-radius: 10px; }
+.day.planned-start::before  { border-top-left-radius: 10px; border-bottom-left-radius: 10px; }
+.day.planned-end::before    { border-top-right-radius: 10px; border-bottom-right-radius: 10px; }
 
 /* 月境界の強線 */
 .month-boundary { border-left: 2px solid #9ca3af !important; }
 
-/* 偶数行のシマ模様（左固定には適用しない） */
-.gantt-table tbody tr:nth-child(even) td:not(.sticky-left) {
-  background: #f5f5f5;
-}
-
-/* 塗りつぶし */
-.gantt-table tbody tr td.day.progress { background-color: var(--color-primary, #60a5fa); }
-.gantt-table tbody tr td.day.planned  { background-color: #93c5fd; }

--- a/asobi-fe/asobi-project-fe/src/app/view/parts/gantt-chart/gantt-chart.component.ts
+++ b/asobi-fe/asobi-project-fe/src/app/view/parts/gantt-chart/gantt-chart.component.ts
@@ -68,6 +68,34 @@ export class GanttChartComponent implements AfterViewInit, OnChanges {
     return date > progressEnd && date <= end;
   }
 
+  isProgressStart(task: Task, date: Date): boolean {
+    return (
+      this.isProgress(task, date) &&
+      !this.isProgress(task, this.addDays(date, -1))
+    );
+  }
+
+  isProgressEnd(task: Task, date: Date): boolean {
+    return (
+      this.isProgress(task, date) &&
+      !this.isProgress(task, this.addDays(date, 1))
+    );
+  }
+
+  isPlannedStart(task: Task, date: Date): boolean {
+    return (
+      this.isPlanned(task, date) &&
+      !this.isPlanned(task, this.addDays(date, -1))
+    );
+  }
+
+  isPlannedEnd(task: Task, date: Date): boolean {
+    return (
+      this.isPlanned(task, date) &&
+      !this.isPlanned(task, this.addDays(date, 1))
+    );
+  }
+
   protected isMonthStart(date: Date): boolean {
     return date.getDate() === 1;
   }

--- a/asobi-fe/asobi-project-fe/src/styles.scss
+++ b/asobi-fe/asobi-project-fe/src/styles.scss
@@ -1,16 +1,19 @@
 /* Global style definitions */
 
 :root {
-  --color-bg: #f5f5f9;
+  --color-bg: #f0f2f5;
+  --color-surface: #fff;
   --color-primary: #3b82f6;
-  --color-text: #333;
+  --color-text: #1f2937;
 }
 
 body {
   margin: 0;
-  font-family: 'Segoe UI', Arial, sans-serif;
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI',
+    'Helvetica Neue', Arial, sans-serif;
   background-color: var(--color-bg);
   color: var(--color-text);
+  line-height: 1.6;
 }
 
 button {
@@ -25,4 +28,19 @@ button {
 
 button:hover {
   background: #2563eb;
+}
+
+/* スクロールバーのスタイル */
+::-webkit-scrollbar {
+  height: 8px;
+  width: 8px;
+}
+
+::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+::-webkit-scrollbar-thumb {
+  background-color: rgba(0, 0, 0, 0.3);
+  border-radius: 4px;
 }


### PR DESCRIPTION
## 概要
- 画面全体のスタイルを洗練し、スクロールバーやフォントをモダン化
- ガントチャートをバー表示中心のモダンなレイアウトに刷新
- ツールバーをカード風の外観に変更

## テスト
- `npm test -- --watch=false --browsers=ChromeHeadless` : `No binary for ChromeHeadless browser on your platform.`


------
https://chatgpt.com/codex/tasks/task_e_689af21a18cc8331a9b9e4addf4c26b0