### PR TITLE
ガントチャート列の視認性向上

### DIFF
--- a/asobi-fe/asobi-project-fe/src/app/view/parts/gantt-chart/gantt-chart.component.scss
+++ b/asobi-fe/asobi-project-fe/src/app/view/parts/gantt-chart/gantt-chart.component.scss
@@ -137,6 +137,17 @@ thead .sticky-left.h {
 .date-col { width: 36px; text-align: center; }
 .day      { width: 36px; padding: 0; position: relative; }
 
+/* 各列の縦罫線（最終列を除く） */
+.date-col,
+.day {
+  border-right: 1px solid #e5e7eb;
+}
+
+.date-col:last-child,
+.day:last-child {
+  border-right: none;
+}
+
 .day::before {
   content: '';
   position: absolute;


### PR DESCRIPTION
## 概要
- ガントチャートの日付列に縦罫線を追加し視認性を向上

## テスト
- `npm test -- --watch=false --browsers=ChromeHeadless` (Chrome が見つからず失敗)


------
https://chatgpt.com/codex/tasks/task_e_689b36436f188331983a37dea50c506d