### PR TITLE
ガントチャートの担当者を追加

### DIFF
--- a/asobi-fe/asobi-project-fe/mock/db.json
+++ b/asobi-fe/asobi-project-fe/mock/db.json
@@ -4,7 +4,7 @@
       "id": 1,
       "title": "顧客ヒアリング",
       "phase": "要件定義",
-      "assignee": "佐藤太郎",
+      "assignee": "山田",
       "startDate": "2025-08-12",
       "endDate": "2025-08-14"
     },
@@ -12,7 +12,7 @@
       "id": 2,
       "title": "業務フロー整理",
       "phase": "要件定義",
-      "assignee": "鈴木花子",
+      "assignee": "山田",
       "startDate": "2025-08-14",
       "endDate": "2025-08-16"
     },
@@ -20,7 +20,7 @@
       "id": 3,
       "title": "要件定義書ドラフト",
       "phase": "要件定義",
-      "assignee": "高橋健",
+      "assignee": "田中",
       "startDate": "2025-08-16",
       "endDate": "2025-08-21"
     },
@@ -28,7 +28,7 @@
       "id": 4,
       "title": "ステークホルダレビュー",
       "phase": "要件定義",
-      "assignee": "田中美咲",
+      "assignee": "田中",
       "startDate": "2025-08-23",
       "endDate": "2025-08-28"
     },
@@ -36,7 +36,7 @@
       "id": 5,
       "title": "要件確定",
       "phase": "要件定義",
-      "assignee": "伊藤大輔",
+      "assignee": "佐藤",
       "startDate": "2025-08-30",
       "endDate": "2025-09-01"
     },
@@ -44,7 +44,7 @@
       "id": 6,
       "title": "リスク分析",
       "phase": "要件定義",
-      "assignee": "山本彩",
+      "assignee": "佐藤",
       "startDate": "2025-09-03",
       "endDate": "2025-09-06"
     },
@@ -52,7 +52,7 @@
       "id": 7,
       "title": "優先順位付け",
       "phase": "要件定義",
-      "assignee": "小林誠",
+      "assignee": "山田",
       "startDate": "2025-09-07",
       "endDate": "2025-09-12"
     },
@@ -60,7 +60,7 @@
       "id": 8,
       "title": "要求仕様書作成",
       "phase": "要件定義",
-      "assignee": "中村明",
+      "assignee": "山田",
       "startDate": "2025-09-13",
       "endDate": "2025-09-18"
     },
@@ -68,7 +68,7 @@
       "id": 9,
       "title": "承認プロセス",
       "phase": "要件定義",
-      "assignee": "加藤直樹",
+      "assignee": "田中",
       "startDate": "2025-09-18",
       "endDate": "2025-09-23"
     },
@@ -76,7 +76,7 @@
       "id": 10,
       "title": "要件サインオフ",
       "phase": "要件定義",
-      "assignee": "吉田光",
+      "assignee": "田中",
       "startDate": "2025-09-24",
       "endDate": "2025-09-29"
     },
@@ -84,7 +84,7 @@
       "id": 11,
       "title": "画面設計",
       "phase": "設計",
-      "assignee": "佐藤太郎",
+      "assignee": "佐藤",
       "startDate": "2025-09-30",
       "endDate": "2025-10-03"
     },
@@ -92,7 +92,7 @@
       "id": 12,
       "title": "DB設計",
       "phase": "設計",
-      "assignee": "鈴木花子",
+      "assignee": "佐藤",
       "startDate": "2025-10-03",
       "endDate": "2025-10-05"
     },
@@ -100,7 +100,7 @@
       "id": 13,
       "title": "アーキテクチャ設計",
       "phase": "設計",
-      "assignee": "高橋健",
+      "assignee": "山田",
       "startDate": "2025-10-07",
       "endDate": "2025-10-11"
     },
@@ -108,7 +108,7 @@
       "id": 14,
       "title": "UIプロトタイプ作成",
       "phase": "設計",
-      "assignee": "田中美咲",
+      "assignee": "山田",
       "startDate": "2025-10-11",
       "endDate": "2025-10-13"
     },
@@ -116,7 +116,7 @@
       "id": 15,
       "title": "レビュー対応",
       "phase": "設計",
-      "assignee": "伊藤大輔",
+      "assignee": "田中",
       "startDate": "2025-10-14",
       "endDate": "2025-10-19"
     },
@@ -124,7 +124,7 @@
       "id": 16,
       "title": "API仕様策定",
       "phase": "設計",
-      "assignee": "山本彩",
+      "assignee": "田中",
       "startDate": "2025-10-19",
       "endDate": "2025-10-22"
     },
@@ -132,7 +132,7 @@
       "id": 17,
       "title": "ユースケース作成",
       "phase": "設計",
-      "assignee": "小林誠",
+      "assignee": "佐藤",
       "startDate": "2025-10-23",
       "endDate": "2025-10-28"
     },
@@ -140,7 +140,7 @@
       "id": 18,
       "title": "設計書レビュー",
       "phase": "設計",
-      "assignee": "中村明",
+      "assignee": "佐藤",
       "startDate": "2025-10-29",
       "endDate": "2025-10-31"
     },
@@ -148,7 +148,7 @@
       "id": 19,
       "title": "設計修正",
       "phase": "設計",
-      "assignee": "加藤直樹",
+      "assignee": "山田",
       "startDate": "2025-11-01",
       "endDate": "2025-11-06"
     },
@@ -156,7 +156,7 @@
       "id": 20,
       "title": "設計確定",
       "phase": "設計",
-      "assignee": "吉田光",
+      "assignee": "山田",
       "startDate": "2025-11-06",
       "endDate": "2025-11-09"
     },
@@ -164,7 +164,7 @@
       "id": 21,
       "title": "ログイン機能実装",
       "phase": "実装",
-      "assignee": "佐藤太郎",
+      "assignee": "田中",
       "startDate": "2025-11-09",
       "endDate": "2025-11-12"
     },
@@ -172,7 +172,7 @@
       "id": 22,
       "title": "ユーザー登録機能実装",
       "phase": "実装",
-      "assignee": "鈴木花子",
+      "assignee": "田中",
       "startDate": "2025-11-13",
       "endDate": "2025-11-16"
     },
@@ -180,7 +180,7 @@
       "id": 23,
       "title": "認証ミドルウェア整備",
       "phase": "実装",
-      "assignee": "高橋健",
+      "assignee": "佐藤",
       "startDate": "2025-11-18",
       "endDate": "2025-11-20"
     },
@@ -188,7 +188,7 @@
       "id": 24,
       "title": "ダッシュボード画面実装",
       "phase": "実装",
-      "assignee": "田中美咲",
+      "assignee": "佐藤",
       "startDate": "2025-11-21",
       "endDate": "2025-11-24"
     },
@@ -196,7 +196,7 @@
       "id": 25,
       "title": "検索機能実装",
       "phase": "実装",
-      "assignee": "伊藤大輔",
+      "assignee": "山田",
       "startDate": "2025-11-26",
       "endDate": "2025-11-30"
     },
@@ -204,7 +204,7 @@
       "id": 26,
       "title": "ページング機能実装",
       "phase": "実装",
-      "assignee": "山本彩",
+      "assignee": "山田",
       "startDate": "2025-12-02",
       "endDate": "2025-12-04"
     },
@@ -212,7 +212,7 @@
       "id": 27,
       "title": "通知機能実装",
       "phase": "実装",
-      "assignee": "小林誠",
+      "assignee": "田中",
       "startDate": "2025-12-06",
       "endDate": "2025-12-11"
     },
@@ -220,7 +220,7 @@
       "id": 28,
       "title": "ファイルアップロード機能実装",
       "phase": "実装",
-      "assignee": "中村明",
+      "assignee": "田中",
       "startDate": "2025-12-11",
       "endDate": "2025-12-15"
     },
@@ -228,7 +228,7 @@
       "id": 29,
       "title": "権限管理機能実装",
       "phase": "実装",
-      "assignee": "加藤直樹",
+      "assignee": "佐藤",
       "startDate": "2025-12-17",
       "endDate": "2025-12-19"
     },
@@ -236,7 +236,7 @@
       "id": 30,
       "title": "アカウント設定画面実装",
       "phase": "実装",
-      "assignee": "吉田光",
+      "assignee": "佐藤",
       "startDate": "2025-12-20",
       "endDate": "2025-12-24"
     },
@@ -244,7 +244,7 @@
       "id": 31,
       "title": "メール送信機能実装",
       "phase": "実装",
-      "assignee": "佐藤太郎",
+      "assignee": "山田",
       "startDate": "2025-12-25",
       "endDate": "2025-12-30"
     },
@@ -252,7 +252,7 @@
       "id": 32,
       "title": "パフォーマンス最適化",
       "phase": "実装",
-      "assignee": "鈴木花子",
+      "assignee": "山田",
       "startDate": "2025-12-30",
       "endDate": "2026-01-03"
     },
@@ -260,7 +260,7 @@
       "id": 33,
       "title": "エラーハンドリング実装",
       "phase": "実装",
-      "assignee": "高橋健",
+      "assignee": "田中",
       "startDate": "2026-01-05",
       "endDate": "2026-01-10"
     },
@@ -268,7 +268,7 @@
       "id": 34,
       "title": "レスポンシブ対応",
       "phase": "実装",
-      "assignee": "田中美咲",
+      "assignee": "田中",
       "startDate": "2026-01-11",
       "endDate": "2026-01-13"
     },
@@ -276,7 +276,7 @@
       "id": 35,
       "title": "ログ出力機能実装",
       "phase": "実装",
-      "assignee": "伊藤大輔",
+      "assignee": "佐藤",
       "startDate": "2026-01-14",
       "endDate": "2026-01-17"
     },
@@ -284,7 +284,7 @@
       "id": 36,
       "title": "キャッシュ機構導入",
       "phase": "実装",
-      "assignee": "山本彩",
+      "assignee": "佐藤",
       "startDate": "2026-01-19",
       "endDate": "2026-01-22"
     },
@@ -292,7 +292,7 @@
       "id": 37,
       "title": "API連携実装",
       "phase": "実装",
-      "assignee": "小林誠",
+      "assignee": "山田",
       "startDate": "2026-01-24",
       "endDate": "2026-01-28"
     },
@@ -300,7 +300,7 @@
       "id": 38,
       "title": "ユニットテスト作成",
       "phase": "実装",
-      "assignee": "中村明",
+      "assignee": "山田",
       "startDate": "2026-01-30",
       "endDate": "2026-02-04"
     },
@@ -308,7 +308,7 @@
       "id": 39,
       "title": "コードレビュー対応",
       "phase": "実装",
-      "assignee": "加藤直樹",
+      "assignee": "田中",
       "startDate": "2026-02-05",
       "endDate": "2026-02-09"
     },
@@ -316,7 +316,7 @@
       "id": 40,
       "title": "実装完了",
       "phase": "実装",
-      "assignee": "吉田光",
+      "assignee": "田中",
       "startDate": "2026-02-10",
       "endDate": "2026-02-15"
     },
@@ -324,7 +324,7 @@
       "id": 41,
       "title": "テスト計画作成",
       "phase": "テスト",
-      "assignee": "佐藤太郎",
+      "assignee": "佐藤",
       "startDate": "2026-02-17",
       "endDate": "2026-02-22"
     },
@@ -332,7 +332,7 @@
       "id": 42,
       "title": "単体テスト実施",
       "phase": "テスト",
-      "assignee": "鈴木花子",
+      "assignee": "佐藤",
       "startDate": "2026-02-22",
       "endDate": "2026-02-27"
     },
@@ -340,7 +340,7 @@
       "id": 43,
       "title": "結合テスト実施",
       "phase": "テスト",
-      "assignee": "高橋健",
+      "assignee": "山田",
       "startDate": "2026-02-27",
       "endDate": "2026-03-02"
     },
@@ -348,7 +348,7 @@
       "id": 44,
       "title": "受け入れテスト調整",
       "phase": "テスト",
-      "assignee": "田中美咲",
+      "assignee": "山田",
       "startDate": "2026-03-03",
       "endDate": "2026-03-05"
     },
@@ -356,7 +356,7 @@
       "id": 45,
       "title": "テスト結果レビュー",
       "phase": "テスト",
-      "assignee": "伊藤大輔",
+      "assignee": "田中",
       "startDate": "2026-03-05",
       "endDate": "2026-03-09"
     },
@@ -364,7 +364,7 @@
       "id": 46,
       "title": "リリース手順作成",
       "phase": "デプロイ",
-      "assignee": "山本彩",
+      "assignee": "田中",
       "startDate": "2026-03-11",
       "endDate": "2026-03-16"
     },
@@ -372,7 +372,7 @@
       "id": 47,
       "title": "ステージング反映",
       "phase": "デプロイ",
-      "assignee": "小林誠",
+      "assignee": "佐藤",
       "startDate": "2026-03-17",
       "endDate": "2026-03-22"
     },
@@ -380,7 +380,7 @@
       "id": 48,
       "title": "本番リリース準備",
       "phase": "デプロイ",
-      "assignee": "中村明",
+      "assignee": "佐藤",
       "startDate": "2026-03-23",
       "endDate": "2026-03-27"
     },
@@ -388,7 +388,7 @@
       "id": 49,
       "title": "リリース実施",
       "phase": "デプロイ",
-      "assignee": "加藤直樹",
+      "assignee": "田中",
       "startDate": "2026-03-29",
       "endDate": "2026-03-31"
     },
@@ -396,7 +396,7 @@
       "id": 50,
       "title": "リリース後確認",
       "phase": "デプロイ",
-      "assignee": "吉田光",
+      "assignee": "佐藤",
       "startDate": "2026-04-02",
       "endDate": "2026-04-05"
     }

--- a/asobi-fe/asobi-project-fe/src/app/infrastructure/api/schedule.api.ts
+++ b/asobi-fe/asobi-project-fe/src/app/infrastructure/api/schedule.api.ts
@@ -7,6 +7,7 @@ interface ApiTask {
   id: number;
   title: string;
   phase: string;
+  assignee: string;
   startDate: string;
   endDate: string;
 }
@@ -23,7 +24,7 @@ export class ScheduleApi {
       type: t.phase,
       name: t.title,
       detail: '',
-      assignee: '',
+      assignee: t.assignee,
       start: new Date(t.startDate),
       end: new Date(t.endDate),
       progress: 0
@@ -35,6 +36,7 @@ export class ScheduleApi {
       id: Number(task.id),
       title: task.name,
       phase: task.type,
+      assignee: task.assignee,
       startDate: task.start.toISOString().split('T')[0],
       endDate: task.end.toISOString().split('T')[0]
     };
@@ -46,6 +48,7 @@ export class ScheduleApi {
       id: Number(task.id),
       title: task.name,
       phase: task.type,
+      assignee: task.assignee,
       startDate: task.start.toISOString().split('T')[0],
       endDate: task.end.toISOString().split('T')[0]
     };


### PR DESCRIPTION
## 概要
- モックデータに山田・田中・佐藤の担当者を割り当て
- ScheduleApiで担当者情報を読み書きできるよう更新

## テスト
- `npm test` (Chrome が必要なため実行失敗)


------
https://chatgpt.com/codex/tasks/task_e_689b35f9ebb083318207deb949edf6f8