### PR TITLE
タスク情報列を中央揃えに

### DIFF
--- a/asobi-fe/asobi-project-fe/src/app/view/parts/gantt-chart/gantt-chart.component.scss
+++ b/asobi-fe/asobi-project-fe/src/app/view/parts/gantt-chart/gantt-chart.component.scss
@@ -52,6 +52,7 @@
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
+  text-align: center;
 }
 
 /* ---------------- ヘッダー固定（2行） ---------------- */


### PR DESCRIPTION
## 概要
- ガントチャートのタスク情報列を中央揃えに

## テスト
- `npm test -- --watch=false --browsers=ChromeHeadless` (ChromeHeadless が見つからず失敗)

------
https://chatgpt.com/codex/tasks/task_e_689b39378c0c8331a4a170863ab47352