### PR TITLE
ガントチャートに列罫線を追加

### DIFF
--- a/asobi-fe/asobi-project-fe/src/app/view/parts/gantt-chart/gantt-chart.component.scss
+++ b/asobi-fe/asobi-project-fe/src/app/view/parts/gantt-chart/gantt-chart.component.scss
@@ -48,7 +48,7 @@
 
 .gantt-table th,
 .gantt-table td {
-  border: none;
+  border-right: 1px solid #e5e7eb;
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;


### PR DESCRIPTION
## Summary
- ガントチャートのタスク情報列と日付列に薄い罫線を追加して視認性を向上

## Testing
- `npm test -- --watch=false --browsers=ChromeHeadless` を実行したが、ChromeHeadless のバイナリが無いため失敗

------
https://chatgpt.com/codex/tasks/task_e_689b36436f188331983a37dea50c506d