### PR TITLE
ガントチャートの上端にボーダーを追加

### DIFF
--- a/asobi-fe/asobi-project-fe/src/app/view/parts/gantt-chart/gantt-chart.component.scss
+++ b/asobi-fe/asobi-project-fe/src/app/view/parts/gantt-chart/gantt-chart.component.scss
@@ -28,6 +28,7 @@
   border-radius: 8px;
   background: var(--color-surface);
   box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
+  border-top: 1px solid #e5e7eb;
 }
 
 /* sticky の基準を1つに限定 */


### PR DESCRIPTION
## 概要
- ガントチャート上端にボーダーを追加し、ツールバーとの境界を明確化

## テスト
- `npm test -- --watch=false --browsers=ChromeHeadless` (ChromeHeadless のバイナリが無く失敗)


------
https://chatgpt.com/codex/tasks/task_e_689b3f9994748331af5af1e164180761