### PR TITLE
fix: ガントチャートのスクロール遅延を改善

### DIFF
--- a/asobi-fe/asobi-project-fe/src/app/view/parts/gantt-chart/gantt-chart.component.html
+++ b/asobi-fe/asobi-project-fe/src/app/view/parts/gantt-chart/gantt-chart.component.html
@@ -19,7 +19,7 @@
 
         <!-- 2行目：日付 -->
         <tr class="head-2">
-          @for (date of dateRange; track $index; let i = $index) {
+          @for (date of dateRange; track date; let i = $index) {
             <th
               class="h date-col"
               [attr.data-idx]="i"
@@ -42,7 +42,7 @@
               <td class="sticky-left col-end">{{ task.end | date : 'yyyy-MM-dd' }}</td>
               <td class="sticky-left col-progress">{{ task.progress }}%</td>
 
-              @for (date of dateRange; track $index; let j = $index) {
+              @for (date of dateRange; track date; let j = $index) {
                 <td
                   class="day"
                   [class.progress]="isProgress(task, date)"
@@ -62,7 +62,7 @@
               <td class="sticky-left col-end"></td>
               <td class="sticky-left col-progress"></td>
 
-              @for (date of dateRange; track $index; let j = $index) {
+              @for (date of dateRange; track date; let j = $index) {
                 <td class="day" [class.month-boundary]="isMonthStart(date) && j !== 0"></td>
               }
             }


### PR DESCRIPTION
## 概要
- スクロール時に日付・タスク列の再描画負荷が高く表示が遅延していた問題を修正
- dateRange の @for ループにおいて index ではなく Date オブジェクトを track することで既存 DOM の再利用を促進

## テスト
- `npm test -- --watch=false --browsers=ChromeHeadless` : Chrome が未インストールのため失敗


------
https://chatgpt.com/codex/tasks/task_e_689b41ac9f088331bb113d6bdee988f7