### PR TITLE
タスクとカレンダー操作のUIをアイコン付きテキストに変更

### DIFF
--- a/asobi-fe/asobi-project-fe/public/add.svg
+++ b/asobi-fe/asobi-project-fe/public/add.svg
@@ -1,4 +1,5 @@
-<svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" fill="none" stroke="#fff" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-  <line x1="12" y1="5" x2="12" y2="19"/>
-  <line x1="5" y1="12" x2="19" y2="12"/>
+<svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" fill="none" stroke="#3b82f6" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <circle cx="12" cy="12" r="10" />
+  <line x1="12" y1="8" x2="12" y2="16" />
+  <line x1="8" y1="12" x2="16" y2="12" />
 </svg>

--- a/asobi-fe/asobi-project-fe/src/app/view/layouts/schedule-layout/schedule-layout.component.html
+++ b/asobi-fe/asobi-project-fe/src/app/view/layouts/schedule-layout/schedule-layout.component.html
@@ -4,10 +4,11 @@
     <div class="toolbar">
       <button class="add-task" (click)="openForm.emit()">
         <img src="add.svg" alt="" class="icon" />
-        タスクを追加
+        <span>タスクを追加</span>
       </button>
-      <button class="open-calendar secondary" (click)="openCalendar.emit()">
-        <img src="calendar.svg" alt="カレンダーを開く" class="icon" />
+      <button class="open-calendar" (click)="openCalendar.emit()">
+        <img src="calendar.svg" alt="" class="icon" />
+        <span>カレンダー</span>
       </button>
     </div>
     <app-gantt-chart #ganttChart [tasks]="tasks"></app-gantt-chart>

--- a/asobi-fe/asobi-project-fe/src/app/view/layouts/schedule-layout/schedule-layout.component.scss
+++ b/asobi-fe/asobi-project-fe/src/app/view/layouts/schedule-layout/schedule-layout.component.scss
@@ -25,28 +25,16 @@
   display: flex;
   align-items: center;
   gap: 0.25rem;
-  background: var(--color-primary);
+  background: none;
   border: none;
-  color: #fff;
-  padding: 0.4rem 0.8rem;
-  border-radius: 6px;
-  cursor: pointer;
-  transition: background-color 0.2s;
-}
-
-.toolbar button.secondary {
-  background: transparent;
-  border: 1px solid var(--color-primary);
   color: var(--color-primary);
+  padding: 0;
+  cursor: pointer;
+  transition: opacity 0.2s;
 }
 
 .toolbar button:hover {
-  background: #2563eb;
-}
-
-.toolbar button.secondary:hover {
-  background: var(--color-primary);
-  color: #fff;
+  opacity: 0.8;
 }
 
 .toolbar .icon {


### PR DESCRIPTION
## 概要
- タスク追加ボタンとカレンダーボタンをアイコン+文字の表示に変更
- タスク追加アイコンを丸付きプラスに刷新

## テスト
- `npm test -- --watch=false --browsers=ChromeHeadless` : ChromeHeadless の実行ファイルがなく失敗

------
https://chatgpt.com/codex/tasks/task_e_689b403118888331b100d4f73229f514