### PR TITLE
feat: add memo notes for gantt chart

### DIFF
--- a/asobi-fe/asobi-project-fe/public/note.svg
+++ b/asobi-fe/asobi-project-fe/public/note.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="none">
+  <rect x="1" y="1" width="14" height="14" rx="1" ry="1" fill="#fee2e2" stroke="#f87171"/>
+</svg>

--- a/asobi-fe/asobi-project-fe/src/app/domain/model/memo.ts
+++ b/asobi-fe/asobi-project-fe/src/app/domain/model/memo.ts
@@ -1,0 +1,8 @@
+export interface Memo {
+  id: string;
+  text: string;
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+}

--- a/asobi-fe/asobi-project-fe/src/app/domain/service/impl/memo.service.impl.ts
+++ b/asobi-fe/asobi-project-fe/src/app/domain/service/impl/memo.service.impl.ts
@@ -1,0 +1,22 @@
+import { Injectable, inject } from '@angular/core';
+import { MemoServiceInterface } from '../interface/memo.service';
+import { Memo } from '../../model/memo';
+import { MemoState } from '../../state/local/memo.state';
+
+@Injectable({ providedIn: 'root' })
+export class MemoService implements MemoServiceInterface {
+  #state = inject(MemoState);
+  readonly memos = this.#state.memos;
+
+  async add(memo: Memo): Promise<void> {
+    this.#state.add(memo);
+  }
+
+  async update(memo: Memo): Promise<void> {
+    this.#state.update(memo);
+  }
+
+  async remove(id: string): Promise<void> {
+    this.#state.remove(id);
+  }
+}

--- a/asobi-fe/asobi-project-fe/src/app/domain/service/interface/memo.service.ts
+++ b/asobi-fe/asobi-project-fe/src/app/domain/service/interface/memo.service.ts
@@ -1,0 +1,9 @@
+import { Signal } from '@angular/core';
+import { Memo } from '../../model/memo';
+
+export interface MemoServiceInterface {
+  readonly memos: Signal<Memo[]>;
+  add(memo: Memo): Promise<void>;
+  update(memo: Memo): Promise<void>;
+  remove(id: string): Promise<void>;
+}

--- a/asobi-fe/asobi-project-fe/src/app/domain/state/interface/memo-state.ts
+++ b/asobi-fe/asobi-project-fe/src/app/domain/state/interface/memo-state.ts
@@ -1,0 +1,9 @@
+import { Signal } from '@angular/core';
+import { Memo } from '../../model/memo';
+
+export interface MemoStateInterface {
+  readonly memos: Signal<Memo[]>;
+  add(memo: Memo): void;
+  update(memo: Memo): void;
+  remove(id: string): void;
+}

--- a/asobi-fe/asobi-project-fe/src/app/domain/state/local/memo.state.ts
+++ b/asobi-fe/asobi-project-fe/src/app/domain/state/local/memo.state.ts
@@ -1,0 +1,21 @@
+import { Injectable, signal } from '@angular/core';
+import { MemoStateInterface } from '../interface/memo-state';
+import { Memo } from '../../model/memo';
+
+@Injectable({ providedIn: 'root' })
+export class MemoState implements MemoStateInterface {
+  #memos = signal<Memo[]>([]);
+  readonly memos = this.#memos.asReadonly();
+
+  add(memo: Memo): void {
+    this.#memos.update(memos => [...memos, memo]);
+  }
+
+  update(memo: Memo): void {
+    this.#memos.update(memos => memos.map(m => m.id === memo.id ? memo : m));
+  }
+
+  remove(id: string): void {
+    this.#memos.update(memos => memos.filter(m => m.id !== id));
+  }
+}

--- a/asobi-fe/asobi-project-fe/src/app/page/schedule/schedule-page.component.html
+++ b/asobi-fe/asobi-project-fe/src/app/page/schedule/schedule-page.component.html
@@ -1,10 +1,16 @@
 <app-schedule-layout
   [tasks]="tasks()"
+  [memos]="memos()"
   [formVisible]="isFormVisible()"
+  [memoVisible]="isMemoVisible()"
   [calendarVisible]="isCalendarVisible()"
   [dateTime]="dateTime()"
   (openForm)="openForm()"
   (closeForm)="closeForm()"
+  (openMemo)="openMemo()"
+  (closeMemo)="closeMemo()"
+  (memoCreate)="onMemoCreate($event)"
+  (memoChange)="onMemoChange($event)"
   (openCalendar)="openCalendar()"
   (closeCalendar)="closeCalendar()"
   (create)="onCreate($event)"></app-schedule-layout>

--- a/asobi-fe/asobi-project-fe/src/app/page/schedule/schedule-page.component.ts
+++ b/asobi-fe/asobi-project-fe/src/app/page/schedule/schedule-page.component.ts
@@ -3,6 +3,8 @@ import { ScheduleLayoutComponent } from '../../view/layouts/schedule-layout/sche
 import { ScheduleService } from '../../domain/service/impl/schedule.service.impl';
 import { Task } from '../../domain/model/task';
 import { ClockService } from '../../domain/service/impl/clock.service.impl';
+import { MemoService } from '../../domain/service/impl/memo.service.impl';
+import { Memo } from '../../domain/model/memo';
 
 @Component({
   selector: 'app-schedule-page',
@@ -14,9 +16,12 @@ import { ClockService } from '../../domain/service/impl/clock.service.impl';
 export class SchedulePageComponent implements OnInit {
   #scheduleService = inject(ScheduleService);
   #clockService = inject(ClockService);
+  #memoService = inject(MemoService);
   protected tasks = this.#scheduleService.tasks;
+  protected memos = this.#memoService.memos;
   protected isFormVisible = signal(false);
   protected isCalendarVisible = signal(false);
+  protected isMemoVisible = signal(false);
   protected dateTime = this.#clockService.now;
 
   ngOnInit(): void {
@@ -40,8 +45,33 @@ export class SchedulePageComponent implements OnInit {
     this.isCalendarVisible.set(false);
   }
 
+  openMemo(): void {
+    this.isMemoVisible.set(true);
+  }
+
+  closeMemo(): void {
+    this.isMemoVisible.set(false);
+  }
+
   onCreate(task: Task): void {
     this.#scheduleService.add(task);
     this.closeForm();
+  }
+
+  onMemoCreate(text: string): void {
+    const memo: Memo = {
+      id: crypto.randomUUID(),
+      text,
+      x: 720,
+      y: 56,
+      width: 120,
+      height: 80,
+    };
+    this.#memoService.add(memo);
+    this.closeMemo();
+  }
+
+  onMemoChange(memo: Memo): void {
+    this.#memoService.update(memo);
   }
 }

--- a/asobi-fe/asobi-project-fe/src/app/view/layouts/schedule-layout/schedule-layout.component.html
+++ b/asobi-fe/asobi-project-fe/src/app/view/layouts/schedule-layout/schedule-layout.component.html
@@ -6,17 +6,32 @@
         <img src="add.svg" alt="" class="icon" />
         <span>タスクを追加</span>
       </button>
+      <button class="add-memo" (click)="openMemo.emit()">
+        <img src="note.svg" alt="" class="icon" />
+        <span>メモを追加</span>
+      </button>
       <button class="open-calendar" (click)="openCalendar.emit()">
         <img src="calendar.svg" alt="" class="icon" />
         <span>カレンダー</span>
       </button>
     </div>
-    <app-gantt-chart #ganttChart [tasks]="tasks"></app-gantt-chart>
+    <app-gantt-chart
+      #ganttChart
+      [tasks]="tasks"
+      [memos]="memos"
+      (memoChange)="memoChange.emit($event)"
+    ></app-gantt-chart>
     @if (calendarVisible) {
       <app-calendar-modal
         (confirm)="onCalendarConfirm($event)"
         (close)="closeCalendar.emit()"
       ></app-calendar-modal>
+    }
+    @if (memoVisible) {
+      <app-memo-modal
+        (confirm)="memoCreate.emit($event)"
+        (close)="closeMemo.emit()"
+      ></app-memo-modal>
     }
     @if (formVisible) {
       <div class="task-dialog" (click)="closeForm.emit()">

--- a/asobi-fe/asobi-project-fe/src/app/view/layouts/schedule-layout/schedule-layout.component.ts
+++ b/asobi-fe/asobi-project-fe/src/app/view/layouts/schedule-layout/schedule-layout.component.ts
@@ -1,15 +1,31 @@
-import { ChangeDetectionStrategy, Component, EventEmitter, Input, Output, ViewChild } from '@angular/core';
+import {
+  ChangeDetectionStrategy,
+  Component,
+  EventEmitter,
+  Input,
+  Output,
+  ViewChild,
+} from '@angular/core';
 import { Task } from '../../../domain/model/task';
+import { Memo } from '../../../domain/model/memo';
 import { GanttChartComponent } from '../../parts/gantt-chart/gantt-chart.component';
 import { TaskFormComponent } from '../../parts/task-form/task-form.component';
 import { HeaderComponent } from '../../parts/header/header.component';
 import { FooterComponent } from '../../parts/footer/footer.component';
 import { CalendarModalComponent } from '../../parts/calendar-modal/calendar-modal.component';
+import { MemoModalComponent } from '../../parts/memo-modal/memo-modal.component';
 
 @Component({
   selector: 'app-schedule-layout',
   standalone: true,
-  imports: [HeaderComponent, GanttChartComponent, TaskFormComponent, FooterComponent, CalendarModalComponent],
+  imports: [
+    HeaderComponent,
+    GanttChartComponent,
+    TaskFormComponent,
+    FooterComponent,
+    CalendarModalComponent,
+    MemoModalComponent,
+  ],
   changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: './schedule-layout.component.html',
   styleUrl: './schedule-layout.component.scss'
@@ -18,12 +34,18 @@ export class ScheduleLayoutComponent {
   @ViewChild('ganttChart') private ganttChart?: GanttChartComponent;
 
   @Input({ required: true }) tasks: Task[] = [];
+  @Input({ required: true }) memos: Memo[] = [];
   @Input() formVisible = false;
+  @Input() memoVisible = false;
   @Input() dateTime = '';
   @Input() calendarVisible = false;
   @Output() create = new EventEmitter<Task>();
   @Output() openForm = new EventEmitter<void>();
   @Output() closeForm = new EventEmitter<void>();
+  @Output() openMemo = new EventEmitter<void>();
+  @Output() closeMemo = new EventEmitter<void>();
+  @Output() memoCreate = new EventEmitter<string>();
+  @Output() memoChange = new EventEmitter<Memo>();
   @Output() openCalendar = new EventEmitter<void>();
   @Output() closeCalendar = new EventEmitter<void>();
 

--- a/asobi-fe/asobi-project-fe/src/app/view/parts/gantt-chart/gantt-chart.component.html
+++ b/asobi-fe/asobi-project-fe/src/app/view/parts/gantt-chart/gantt-chart.component.html
@@ -70,5 +70,24 @@
         }
       </tbody>
     </table>
+    <div class="memo-layer">
+      @for (memo of memos; track memo.id) {
+        <div
+          class="memo"
+          [style.left.px]="memo.x"
+          [style.top.px]="memo.y"
+          [style.width.px]="memo.width"
+          [style.height.px]="memo.height"
+          (mousedown)="onMemoMouseDown($event, memo)"
+          (mouseup)="onMemoMouseUp(memo, $event.currentTarget as HTMLElement)"
+        >
+          <div
+            class="memo-body"
+            contenteditable
+            (blur)="onMemoBlur(memo, $event.target as HTMLElement)"
+          >{{ memo.text }}</div>
+        </div>
+      }
+    </div>
   </div>
 </div>

--- a/asobi-fe/asobi-project-fe/src/app/view/parts/gantt-chart/gantt-chart.component.scss
+++ b/asobi-fe/asobi-project-fe/src/app/view/parts/gantt-chart/gantt-chart.component.scss
@@ -36,6 +36,7 @@
   width: 100%;
   height: 100%;
   overflow: auto; /* 縦横ここで */
+  position: relative;
 }
 
 /* sticky と相性が良い separate を採用（Safari 安定） */
@@ -171,4 +172,29 @@ thead .sticky-left.h {
 
 /* 月境界の強線 */
 .month-boundary { border-left: 2px solid #9ca3af !important; }
+
+/* ---------------- メモ ---------------- */
+.memo-layer {
+  position: absolute;
+  top: 0;
+  left: 0;
+}
+
+.memo {
+  position: absolute;
+  background: #fee2e2;
+  border: 1px solid #f87171;
+  resize: both;
+  overflow: hidden;
+  cursor: move;
+}
+
+.memo .memo-body {
+  padding: 4px;
+  width: 100%;
+  height: 100%;
+  overflow: auto;
+  outline: none;
+  cursor: text;
+}
 

--- a/asobi-fe/asobi-project-fe/src/app/view/parts/memo-modal/memo-modal.component.html
+++ b/asobi-fe/asobi-project-fe/src/app/view/parts/memo-modal/memo-modal.component.html
@@ -1,0 +1,9 @@
+<div class="memo-modal" (click)="close.emit()">
+  <div class="dialog" (click)="$event.stopPropagation()">
+    <h2>メモ</h2>
+    <textarea [(ngModel)]="text" rows="5"></textarea>
+    <div class="actions">
+      <button class="confirm" (click)="confirm.emit(text)">決定</button>
+    </div>
+  </div>
+</div>

--- a/asobi-fe/asobi-project-fe/src/app/view/parts/memo-modal/memo-modal.component.scss
+++ b/asobi-fe/asobi-project-fe/src/app/view/parts/memo-modal/memo-modal.component.scss
@@ -1,0 +1,28 @@
+.memo-modal {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.4);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+}
+
+.memo-modal .dialog {
+  background: #fff;
+  padding: 1.5rem;
+  border-radius: 8px;
+  width: 300px;
+  max-width: 90%; 
+  box-shadow: 0 2px 10px rgba(0, 0, 0, 0.2);
+}
+
+.memo-modal textarea {
+  width: 100%;
+  box-sizing: border-box;
+}
+
+.memo-modal .actions {
+  text-align: right;
+  margin-top: 1rem;
+}

--- a/asobi-fe/asobi-project-fe/src/app/view/parts/memo-modal/memo-modal.component.ts
+++ b/asobi-fe/asobi-project-fe/src/app/view/parts/memo-modal/memo-modal.component.ts
@@ -1,0 +1,16 @@
+import { ChangeDetectionStrategy, Component, EventEmitter, Output } from '@angular/core';
+import { FormsModule } from '@angular/forms';
+
+@Component({
+  selector: 'app-memo-modal',
+  standalone: true,
+  imports: [FormsModule],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  templateUrl: './memo-modal.component.html',
+  styleUrl: './memo-modal.component.scss'
+})
+export class MemoModalComponent {
+  text = '';
+  @Output() confirm = new EventEmitter<string>();
+  @Output() close = new EventEmitter<void>();
+}


### PR DESCRIPTION
## Summary
- ガントチャート上にメモを貼り付け・編集・移動できる機能を追加
- メモ追加用のモーダルとツールバーのボタンを実装
- メモ状態を管理するモデル・サービス・ステートを導入

## Testing
- `npm test` (Chrome 未インストールのため失敗)

------
https://chatgpt.com/codex/tasks/task_e_689b465f2df08331a5c15db035bf6d09