### PR TITLE
fix: メモイベントの型エラー修正

### DIFF
--- a/asobi-fe/asobi-project-fe/src/app/view/parts/gantt-chart/gantt-chart.component.html
+++ b/asobi-fe/asobi-project-fe/src/app/view/parts/gantt-chart/gantt-chart.component.html
@@ -79,12 +79,12 @@
           [style.width.px]="memo.width"
           [style.height.px]="memo.height"
           (mousedown)="onMemoMouseDown($event, memo)"
-          (mouseup)="onMemoMouseUp(memo, $event.currentTarget as HTMLElement)"
+          (mouseup)="onMemoMouseUp($event, memo)"
         >
           <div
             class="memo-body"
             contenteditable
-            (blur)="onMemoBlur(memo, $event.target as HTMLElement)"
+            (blur)="onMemoBlur($event, memo)"
           >{{ memo.text }}</div>
         </div>
       }

--- a/asobi-fe/asobi-project-fe/src/app/view/parts/gantt-chart/gantt-chart.component.ts
+++ b/asobi-fe/asobi-project-fe/src/app/view/parts/gantt-chart/gantt-chart.component.ts
@@ -175,15 +175,19 @@ export class GanttChartComponent implements AfterViewInit, OnChanges {
     event.preventDefault();
   }
 
-  onMemoBlur(memo: Memo, el: HTMLElement): void {
+  onMemoBlur(event: FocusEvent, memo: Memo): void {
+    const el = event.target as HTMLElement | null;
+    if (!el) return;
     memo.text = el.innerText;
     memo.width = el.offsetWidth;
     memo.height = el.offsetHeight;
     this.memoChange.emit({ ...memo });
   }
 
-  onMemoMouseUp(memo: Memo, el: HTMLElement): void {
+  onMemoMouseUp(event: MouseEvent, memo: Memo): void {
     if (this.dragData) return;
+    const el = event.currentTarget as HTMLElement | null;
+    if (!el) return;
     memo.width = el.offsetWidth;
     memo.height = el.offsetHeight;
     memo.text = el.innerText;


### PR DESCRIPTION
## Summary
- メモのmouseup/blurイベントで発生していたAngularテンプレート解析エラーを解消
- イベントオブジェクトから要素を取得する方式に変更し、nullチェックを追加

## Testing
- `npm run build`
- `npm test -- --watch=false --browsers=ChromeHeadless` *(CHROME_BINが未設定のためブラウザ起動失敗)*

------
https://chatgpt.com/codex/tasks/task_e_689b4a079ea883318344c03de1e3945a