### PR TITLE
メモ追加時の配置をフォーカスセルまたは今日列に変更

### DIFF
--- a/asobi-fe/asobi-project-fe/src/app/page/schedule/schedule-page.component.ts
+++ b/asobi-fe/asobi-project-fe/src/app/page/schedule/schedule-page.component.ts
@@ -58,12 +58,12 @@ export class SchedulePageComponent implements OnInit {
     this.closeForm();
   }
 
-  onMemoCreate(text: string): void {
+  onMemoCreate(event: { text: string; x: number; y: number }): void {
     const memo: Memo = {
       id: crypto.randomUUID(),
-      text,
-      x: 720,
-      y: 56,
+      text: event.text,
+      x: event.x,
+      y: event.y,
       width: 120,
       height: 80,
     };

--- a/asobi-fe/asobi-project-fe/src/app/view/layouts/schedule-layout/schedule-layout.component.html
+++ b/asobi-fe/asobi-project-fe/src/app/view/layouts/schedule-layout/schedule-layout.component.html
@@ -29,7 +29,7 @@
     }
     @if (memoVisible) {
       <app-memo-modal
-        (confirm)="memoCreate.emit($event)"
+        (confirm)="onMemoConfirm($event)"
         (close)="closeMemo.emit()"
       ></app-memo-modal>
     }

--- a/asobi-fe/asobi-project-fe/src/app/view/layouts/schedule-layout/schedule-layout.component.ts
+++ b/asobi-fe/asobi-project-fe/src/app/view/layouts/schedule-layout/schedule-layout.component.ts
@@ -44,7 +44,7 @@ export class ScheduleLayoutComponent {
   @Output() closeForm = new EventEmitter<void>();
   @Output() openMemo = new EventEmitter<void>();
   @Output() closeMemo = new EventEmitter<void>();
-  @Output() memoCreate = new EventEmitter<string>();
+  @Output() memoCreate = new EventEmitter<{ text: string; x: number; y: number }>();
   @Output() memoChange = new EventEmitter<Memo>();
   @Output() openCalendar = new EventEmitter<void>();
   @Output() closeCalendar = new EventEmitter<void>();
@@ -52,5 +52,12 @@ export class ScheduleLayoutComponent {
   onCalendarConfirm(date: Date): void {
     this.ganttChart?.scrollToDate(date);
     this.closeCalendar.emit();
+  }
+
+  onMemoConfirm(text: string): void {
+    const pos =
+      this.ganttChart?.getFocusedCellPosition() ??
+      this.ganttChart?.getTodayColumnPosition();
+    this.memoCreate.emit({ text, x: pos?.x ?? 0, y: pos?.y ?? 0 });
   }
 }

--- a/asobi-fe/asobi-project-fe/src/app/view/parts/gantt-chart/gantt-chart.component.html
+++ b/asobi-fe/asobi-project-fe/src/app/view/parts/gantt-chart/gantt-chart.component.html
@@ -45,6 +45,7 @@
               @for (date of dateRange; track date; let j = $index) {
                 <td
                   class="day"
+                  (mousedown)="onCellMouseDown($event)"
                   [class.progress]="isProgress(task, date)"
                   [class.planned]="isPlanned(task, date)"
                   [class.progress-start]="isProgressStart(task, date)"
@@ -63,7 +64,11 @@
               <td class="sticky-left col-progress"></td>
 
               @for (date of dateRange; track date; let j = $index) {
-                <td class="day" [class.month-boundary]="isMonthStart(date) && j !== 0"></td>
+                <td
+                  class="day"
+                  (mousedown)="onCellMouseDown($event)"
+                  [class.month-boundary]="isMonthStart(date) && j !== 0"
+                ></td>
               }
             }
           </tr>

--- a/asobi-fe/asobi-project-fe/src/app/view/parts/gantt-chart/gantt-chart.component.ts
+++ b/asobi-fe/asobi-project-fe/src/app/view/parts/gantt-chart/gantt-chart.component.ts
@@ -36,6 +36,7 @@ export class GanttChartComponent implements AfterViewInit, OnChanges {
   private dragData?: { memo: Memo; el: HTMLElement; offsetX: number; offsetY: number };
   private onMove = (e: MouseEvent) => this.handleDrag(e);
   private onUp = () => this.endDrag();
+  private focusedCell?: { x: number; y: number };
 
   constructor(private cdr: ChangeDetectorRef) {
     const start = this.getToday();
@@ -162,6 +163,33 @@ export class GanttChartComponent implements AfterViewInit, OnChanges {
         host.scrollLeft += host.scrollWidth - prevWidth;
       }
     });
+  }
+
+  onCellMouseDown(event: MouseEvent): void {
+    const host = this.scrollHost?.nativeElement;
+    const cell = event.currentTarget as HTMLElement | null;
+    if (!host || !cell) return;
+    const hostRect = host.getBoundingClientRect();
+    const cellRect = cell.getBoundingClientRect();
+    this.focusedCell = {
+      x: cellRect.left - hostRect.left + host.scrollLeft,
+      y: cellRect.top - hostRect.top + host.scrollTop,
+    };
+  }
+
+  getFocusedCellPosition(): { x: number; y: number } | null {
+    return this.focusedCell ?? null;
+  }
+
+  getTodayColumnPosition(): { x: number; y: number } {
+    const host = this.scrollHost?.nativeElement;
+    if (!host) return { x: 0, y: 0 };
+    const headerHeight = this.getHeaderHeight(host);
+    const today = this.getToday();
+    const idx = this.dateRange.findIndex((d) => this.isSameDay(d, today));
+    const th = host.querySelector<HTMLElement>(`.head-2 th[data-idx="${idx}"]`);
+    const x = th ? th.offsetLeft : 0;
+    return { x, y: headerHeight };
   }
 
   onMemoMouseDown(event: MouseEvent, memo: Memo): void {


### PR DESCRIPTION
## 概要
- メモ追加時の初期位置を直前にクリックしたセルへ配置
- フォーカスセルがない場合は今日の列の先頭に配置

## テスト
- `npm test -- --watch=false --browsers=ChromeHeadless`（ChromeHeadless が存在せず失敗）

------
https://chatgpt.com/codex/tasks/task_e_689b4cebdec483319ba40baf8f2ff9bb