### PR TITLE
feat: enable memo drag and edit

### DIFF
--- a/asobi-fe/asobi-project-fe/public/edit.svg
+++ b/asobi-fe/asobi-project-fe/public/edit.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <path d="M12 20h9"/>
+  <path d="M16.5 3.5a2.121 2.121 0 013 3L7 19l-4 1 1-4L16.5 3.5z"/>
+</svg>

--- a/asobi-fe/asobi-project-fe/src/app/view/parts/gantt-chart/gantt-chart.component.html
+++ b/asobi-fe/asobi-project-fe/src/app/view/parts/gantt-chart/gantt-chart.component.html
@@ -75,24 +75,33 @@
         }
       </tbody>
     </table>
-    <div class="memo-layer">
-      @for (memo of memos; track memo.id) {
-        <div
-          class="memo"
-          [style.left.px]="memo.x"
-          [style.top.px]="memo.y"
-          [style.width.px]="memo.width"
-          [style.height.px]="memo.height"
-          (mousedown)="onMemoMouseDown($event, memo)"
-          (mouseup)="onMemoMouseUp($event, memo)"
-        >
+      <div class="memo-layer">
+        @for (memo of memos; track memo.id) {
           <div
-            class="memo-body"
-            contenteditable
-            (blur)="onMemoBlur($event, memo)"
-          >{{ memo.text }}</div>
-        </div>
-      }
-    </div>
+            class="memo"
+            [class.editing]="editingMemoId === memo.id"
+            [style.left.px]="memo.x"
+            [style.top.px]="memo.y"
+            [style.width.px]="memo.width"
+            [style.height.px]="memo.height"
+            (mousedown)="onMemoMouseDown($event, memo)"
+            (mouseup)="onMemoMouseUp($event, memo)"
+          >
+            <button
+              class="edit-button"
+              (click)="startEdit(memo, memoBody, $event)"
+            >
+              <img src="edit.svg" alt="" class="icon" />
+              <span>編集</span>
+            </button>
+            <div
+              #memoBody
+              class="memo-body"
+              [attr.contenteditable]="editingMemoId === memo.id ? 'true' : null"
+              (blur)="onMemoBlur($event, memo)"
+            >{{ memo.text }}</div>
+          </div>
+        }
+      </div>
   </div>
 </div>

--- a/asobi-fe/asobi-project-fe/src/app/view/parts/gantt-chart/gantt-chart.component.scss
+++ b/asobi-fe/asobi-project-fe/src/app/view/parts/gantt-chart/gantt-chart.component.scss
@@ -186,15 +186,41 @@ thead .sticky-left.h {
   border: 1px solid #f87171;
   resize: both;
   overflow: hidden;
+}
+
+.memo.editing {
+  cursor: text;
+}
+
+.memo:not(.editing) {
   cursor: move;
 }
 
 .memo .memo-body {
-  padding: 4px;
+  padding: 20px 4px 4px;
   width: 100%;
   height: 100%;
   overflow: auto;
   outline: none;
-  cursor: text;
+  cursor: inherit;
+}
+
+.memo .edit-button {
+  position: absolute;
+  top: 0;
+  left: 0;
+  display: flex;
+  align-items: center;
+  background: rgba(255, 255, 255, 0.7);
+  border: none;
+  padding: 2px 4px;
+  font-size: 10px;
+  cursor: pointer;
+}
+
+.memo .edit-button .icon {
+  width: 12px;
+  height: 12px;
+  margin-right: 2px;
 }
 


### PR DESCRIPTION
## Summary
- allow dragging memos by clicking anywhere on them
- add edit button and inline editing mode for memos

## Testing
- `npm test -- --watch=false --browsers=ChromiumHeadless` (fails: Command '/usr/bin/chromium-browser' requires the chromium snap to be installed)

------
https://chatgpt.com/codex/tasks/task_e_689b4fc29fa083319b8288df528048d4