### PR TITLE
メモのドラッグ位置計算にスクロール量を反映

### DIFF
--- a/asobi-fe/asobi-project-fe/src/app/view/parts/gantt-chart/gantt-chart.component.ts
+++ b/asobi-fe/asobi-project-fe/src/app/view/parts/gantt-chart/gantt-chart.component.ts
@@ -239,8 +239,10 @@ export class GanttChartComponent implements AfterViewInit, OnChanges {
     const rect = host.getBoundingClientRect();
     const stickyWidth = this.getStickyWidth(host);
     const headerHeight = this.getHeaderHeight(host);
-    const x = event.clientX - rect.left - this.dragData.offsetX;
-    const y = event.clientY - rect.top - this.dragData.offsetY;
+    const x =
+      event.clientX - rect.left + host.scrollLeft - this.dragData.offsetX;
+    const y =
+      event.clientY - rect.top + host.scrollTop - this.dragData.offsetY;
     const maxX = host.scrollWidth - this.dragData.el.offsetWidth;
     const maxY = host.scrollHeight - this.dragData.el.offsetHeight;
     this.dragData.memo.x = Math.min(Math.max(x, stickyWidth), maxX);


### PR DESCRIPTION
## 概要
- メモをドラッグした際にスクロール位置を考慮して座標を計算するよう修正

## テスト
- `CHROME_BIN=/usr/bin/chromium-browser npm test -- --watch=false --browsers=ChromeHeadless` (ChromeHeadless が snap 依存のため起動不可)


------
https://chatgpt.com/codex/tasks/task_e_689b525965cc8331b2fddabc603e8ccb