### PR TITLE
メモ編集ボタン再押下で編集終了できるよう修正

### DIFF
--- a/asobi-fe/asobi-project-fe/src/app/view/parts/gantt-chart/gantt-chart.component.html
+++ b/asobi-fe/asobi-project-fe/src/app/view/parts/gantt-chart/gantt-chart.component.html
@@ -87,13 +87,13 @@
             (mousedown)="onMemoMouseDown($event, memo)"
             (mouseup)="onMemoMouseUp($event, memo)"
           >
-            <button
-              class="edit-button"
-              (click)="startEdit(memo, memoBody, $event)"
-            >
-              <img src="edit.svg" alt="" class="icon" />
-              <span>編集</span>
-            </button>
+              <button
+                class="edit-button"
+                (mousedown)="toggleEdit(memo, memoBody, $event)"
+              >
+                <img src="edit.svg" alt="" class="icon" />
+                <span>編集</span>
+              </button>
             <div
               #memoBody
               class="memo-body"

--- a/asobi-fe/asobi-project-fe/src/app/view/parts/gantt-chart/gantt-chart.component.ts
+++ b/asobi-fe/asobi-project-fe/src/app/view/parts/gantt-chart/gantt-chart.component.ts
@@ -226,8 +226,17 @@ export class GanttChartComponent implements AfterViewInit, OnChanges {
     this.memoChange.emit({ ...memo });
   }
 
-  protected startEdit(memo: Memo, el: HTMLElement, event: MouseEvent): void {
+  protected toggleEdit(
+    memo: Memo,
+    el: HTMLElement,
+    event: MouseEvent,
+  ): void {
     event.stopPropagation();
+    event.preventDefault();
+    if (this.editingMemoId === memo.id) {
+      el.blur();
+      return;
+    }
     this.editingMemoId = memo.id;
     setTimeout(() => el.focus());
   }


### PR DESCRIPTION
## 概要
- メモ編集中に再度編集ボタンを押した際に編集を終了できるように修正

## テスト
- `CHROME_BIN=chromium-browser npm test -- --watch=false` : Chrome が snap 未インストールのため起動失敗

------
https://chatgpt.com/codex/tasks/task_e_689b54e9578483318eef3ffbe08f7ddd