### PR TITLE
fix: 付箋メモの角のデザインを改善

### DIFF
--- a/asobi-fe/asobi-project-fe/src/app/view/parts/gantt-chart/gantt-chart.component.scss
+++ b/asobi-fe/asobi-project-fe/src/app/view/parts/gantt-chart/gantt-chart.component.scss
@@ -238,8 +238,10 @@ thead .sticky-left.h {
   border: none;
   resize: both;
   overflow: hidden;
+  border-radius: 4px;
 }
 
+.memo::before,
 .memo::after {
   content: "";
   position: absolute;
@@ -247,10 +249,22 @@ thead .sticky-left.h {
   right: 0;
   width: 0;
   height: 0;
-  border-left: 20px solid transparent;
-  border-bottom: 20px solid #fde68a;
-  box-shadow: -2px 2px 2px rgba(0, 0, 0, 0.1);
   pointer-events: none;
+}
+
+.memo::before {
+  border-style: solid;
+  border-width: 0 20px 20px 0;
+  border-color: transparent #fef9c3 #fef9c3 transparent;
+  z-index: 2;
+}
+
+.memo::after {
+  border-style: solid;
+  border-width: 0 0 20px 20px;
+  border-color: transparent transparent #fde68a transparent;
+  box-shadow: -2px 2px 2px rgba(0, 0, 0, 0.1);
+  z-index: 1;
 }
 
 .memo.editing {


### PR DESCRIPTION
## 概要
- 付箋メモの角を折り曲げたように見えるデザインに修正

## テスト
- `npm test -- --watch=false` : Chrome が見つからず失敗

------
https://chatgpt.com/codex/tasks/task_e_689b54824d7083318bdbfe92bc7f2548