### PR TITLE
メモ右上角を折りたたみ形状に修正

### DIFF
--- a/asobi-fe/asobi-project-fe/src/app/view/parts/gantt-chart/gantt-chart.component.html
+++ b/asobi-fe/asobi-project-fe/src/app/view/parts/gantt-chart/gantt-chart.component.html
@@ -87,6 +87,7 @@
             (mousedown)="onMemoMouseDown($event, memo)"
             (mouseup)="onMemoMouseUp($event, memo)"
           >
+            <div class="memo-content">
               <button
                 class="edit-button"
                 (mousedown)="toggleEdit(memo, memoBody, $event)"
@@ -94,12 +95,13 @@
                 <img src="edit.svg" alt="" class="icon" />
                 <span>編集</span>
               </button>
-            <div
-              #memoBody
-              class="memo-body"
-              [attr.contenteditable]="editingMemoId === memo.id ? 'true' : null"
-              (blur)="onMemoBlur($event, memo)"
-            >{{ memo.text }}</div>
+              <div
+                #memoBody
+                class="memo-body"
+                [attr.contenteditable]="editingMemoId === memo.id ? 'true' : null"
+                (blur)="onMemoBlur($event, memo)"
+              >{{ memo.text }}</div>
+            </div>
           </div>
         }
       </div>

--- a/asobi-fe/asobi-project-fe/src/app/view/parts/gantt-chart/gantt-chart.component.scss
+++ b/asobi-fe/asobi-project-fe/src/app/view/parts/gantt-chart/gantt-chart.component.scss
@@ -233,12 +233,18 @@ thead .sticky-left.h {
 
 .memo {
   position: absolute;
+  resize: both;
+}
+
+.memo .memo-content {
+  width: 100%;
+  height: 100%;
   background: #fef9c3;
   box-shadow: 0 2px 4px rgba(0, 0, 0, 0.2);
   border: none;
-  resize: both;
   overflow: hidden;
   border-radius: 4px;
+  clip-path: polygon(0 0, calc(100% - 20px) 0, 100% 20px, 100% 100%, 0 100%);
 }
 
 .memo::before,


### PR DESCRIPTION
## Summary
- メモ表示を包む`memo-content`要素を追加し、五角形のクリップパスで右上角をカット
- 既存の折り返し表現を維持しつつ、余分な右上角を削除してデザインを調整

## Testing
- `npm test -- --watch=false` (Chrome が無いため失敗)


------
https://chatgpt.com/codex/tasks/task_e_689b5c37ff288331a75b5010c97e48c5