### PR TITLE
メモドラッグ時に位置が即座に反映されるように修正

### DIFF
--- a/asobi-fe/asobi-project-fe/src/app/view/parts/gantt-chart/gantt-chart.component.ts
+++ b/asobi-fe/asobi-project-fe/src/app/view/parts/gantt-chart/gantt-chart.component.ts
@@ -295,7 +295,7 @@ export class GanttChartComponent implements AfterViewInit, OnChanges {
     const maxY = host.scrollHeight - this.dragData.el.offsetHeight;
     this.dragData.memo.x = Math.min(Math.max(x, stickyWidth), maxX);
     this.dragData.memo.y = Math.min(Math.max(y, headerHeight), maxY);
-    this.cdr.markForCheck();
+    this.cdr.detectChanges();
   }
 
   private handleResize(event: MouseEvent): void {
@@ -307,7 +307,7 @@ export class GanttChartComponent implements AfterViewInit, OnChanges {
     el.style.height = `${height}px`;
     memo.width = el.offsetWidth;
     memo.height = el.offsetHeight;
-    this.cdr.markForCheck();
+    this.cdr.detectChanges();
   }
 
   private endDrag(): void {


### PR DESCRIPTION
## 概要
- メモのドラッグ／リサイズ中に `ChangeDetectorRef.markForCheck()` を使用していたため、ゾーン非依存構成では変更検知が走らず位置が更新されていませんでした
- `ChangeDetectorRef.detectChanges()` を呼び出すようにして、マウス操作中もリアルタイムに描画が更新されるように修正

## テスト
- `npm test` (Chrome が見つからず失敗)


------
https://chatgpt.com/codex/tasks/task_e_689bf04ed9d0833183f7c6c6cecab75a