### PR TITLE
列ホバーとセルフォーカス表示を追加

### DIFF
--- a/asobi-fe/asobi-project-fe/src/app/view/parts/gantt-chart/gantt-chart.component.html
+++ b/asobi-fe/asobi-project-fe/src/app/view/parts/gantt-chart/gantt-chart.component.html
@@ -24,6 +24,9 @@
               class="h date-col"
               [attr.data-idx]="i"
               [class.month-boundary]="isMonthStart(date) && i !== 0"
+              (mouseenter)="onColumnMouseEnter(i)"
+              (mouseleave)="onColumnMouseLeave()"
+              [class.column-hover]="hoveredColIdx === i"
             >
               {{ date | date : 'dd' }}
             </th>
@@ -45,7 +48,11 @@
               @for (date of dateRange; track date; let j = $index) {
                 <td
                   class="day"
-                  (mousedown)="onCellMouseDown($event)"
+                  (mousedown)="onCellMouseDown($event, i, j)"
+                  (mouseenter)="onColumnMouseEnter(j)"
+                  (mouseleave)="onColumnMouseLeave()"
+                  [class.column-hover]="hoveredColIdx === j"
+                  [class.focused]="isFocusedCell(i, j)"
                   [class.progress]="isProgress(task, date)"
                   [class.planned]="isPlanned(task, date)"
                   [class.progress-start]="isProgressStart(task, date)"
@@ -61,17 +68,21 @@
               <td class="sticky-left col-assignee"></td>
               <td class="sticky-left col-start"></td>
               <td class="sticky-left col-end"></td>
-              <td class="sticky-left col-progress"></td>
+                <td class="sticky-left col-progress"></td>
 
-              @for (date of dateRange; track date; let j = $index) {
-                <td
-                  class="day"
-                  (mousedown)="onCellMouseDown($event)"
-                  [class.month-boundary]="isMonthStart(date) && j !== 0"
-                ></td>
+                @for (date of dateRange; track date; let j = $index) {
+                  <td
+                    class="day"
+                    (mousedown)="onCellMouseDown($event, i, j)"
+                    (mouseenter)="onColumnMouseEnter(j)"
+                    (mouseleave)="onColumnMouseLeave()"
+                    [class.column-hover]="hoveredColIdx === j"
+                    [class.focused]="isFocusedCell(i, j)"
+                    [class.month-boundary]="isMonthStart(date) && j !== 0"
+                  ></td>
+                }
               }
-            }
-          </tr>
+            </tr>
         }
       </tbody>
     </table>

--- a/asobi-fe/asobi-project-fe/src/app/view/parts/gantt-chart/gantt-chart.component.scss
+++ b/asobi-fe/asobi-project-fe/src/app/view/parts/gantt-chart/gantt-chart.component.scss
@@ -162,6 +162,15 @@ thead .sticky-left.h {
   background: #f3f4f6;
 }
 
+.gantt-table th.column-hover,
+.gantt-table td.column-hover {
+  background: #f3f4f6;
+}
+
+.gantt-table td.focused {
+  background: #fee2e2 !important;
+}
+
 /* 日付列のヘッダー/ボディ幅 */
 .date-col {
   width: 36px;

--- a/asobi-fe/asobi-project-fe/src/app/view/parts/gantt-chart/gantt-chart.component.ts
+++ b/asobi-fe/asobi-project-fe/src/app/view/parts/gantt-chart/gantt-chart.component.ts
@@ -50,6 +50,8 @@ export class GanttChartComponent implements AfterViewInit, OnChanges {
   private onResizeMove = (e: MouseEvent) => this.handleResize(e);
   private onResizeUp = () => this.endResize();
   private focusedCell?: { x: number; y: number };
+  private focusedCellIdx?: { row: number; col: number };
+  protected hoveredColIdx: number | null = null;
   protected editingMemoId: string | null = null;
 
   constructor(private cdr: ChangeDetectorRef) {
@@ -187,7 +189,7 @@ export class GanttChartComponent implements AfterViewInit, OnChanges {
     });
   }
 
-  onCellMouseDown(event: MouseEvent): void {
+  onCellMouseDown(event: MouseEvent, rowIdx: number, colIdx: number): void {
     const host = this.scrollHost?.nativeElement;
     const cell = event.currentTarget as HTMLElement | null;
     if (!host || !cell) return;
@@ -197,6 +199,7 @@ export class GanttChartComponent implements AfterViewInit, OnChanges {
       x: cellRect.left - hostRect.left + host.scrollLeft,
       y: cellRect.top - hostRect.top + host.scrollTop,
     };
+    this.focusedCellIdx = { row: rowIdx, col: colIdx };
   }
 
   getFocusedCellPosition(): { x: number; y: number } | null {
@@ -225,6 +228,18 @@ export class GanttChartComponent implements AfterViewInit, OnChanges {
     document.addEventListener('mousemove', this.onMove);
     document.addEventListener('mouseup', this.onUp);
     event.preventDefault();
+  }
+
+  onColumnMouseEnter(colIdx: number): void {
+    this.hoveredColIdx = colIdx;
+  }
+
+  onColumnMouseLeave(): void {
+    this.hoveredColIdx = null;
+  }
+
+  protected isFocusedCell(row: number, col: number): boolean {
+    return this.focusedCellIdx?.row === row && this.focusedCellIdx?.col === col;
   }
 
   onMemoResizeMouseDown(event: MouseEvent, memo: Memo): void {


### PR DESCRIPTION
## 概要
- ガントチャートで列ホバー時に列全体を強調表示
- クリックしたセルを薄い赤で表示

## テスト
- `npm test -- --watch=false --browsers=ChromeHeadless` (ChromeHeadless 未インストールのため失敗)


------
https://chatgpt.com/codex/tasks/task_e_689bf5f70d3883318fa279e4d9bf330d