### PR TITLE
タスク情報列の幅がスクロール位置で変わる問題を修正

### DIFF
--- a/asobi-fe/asobi-project-fe/src/app/view/parts/gantt-chart/gantt-chart.component.scss
+++ b/asobi-fe/asobi-project-fe/src/app/view/parts/gantt-chart/gantt-chart.component.scss
@@ -37,6 +37,7 @@
   height: 100%;
   overflow: auto; /* 縦横ここで */
   position: relative;
+  scrollbar-gutter: stable;
 }
 
 /* sticky と相性が良い separate を採用（Safari 安定） */
@@ -55,6 +56,7 @@
   overflow: hidden;
   text-overflow: ellipsis;
   text-align: center;
+  box-sizing: border-box;
 }
 
 /* ---------------- ヘッダー固定（2行） ---------------- */


### PR DESCRIPTION
## 概要
- gantt-chart のスクロールコンテナに `scrollbar-gutter: stable` を追加
- セルの `box-sizing` を `border-box` に変更し、列幅を安定化

## テスト
- `npm test` 実行（Chrome が無いため失敗）

------
https://chatgpt.com/codex/tasks/task_e_689bf59faad88331bb519d8a38e17987