### PR TITLE
feat: タスク詳細モーダルを追加

### DIFF
--- a/asobi-fe/asobi-project-fe/public/trash.svg
+++ b/asobi-fe/asobi-project-fe/public/trash.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <polyline points="3 6 5 6 21 6" />
+  <path d="M19 6l-2 14H7L5 6m5-3h4l1 3H9l1-3z" />
+</svg>

--- a/asobi-fe/asobi-project-fe/src/app/page/schedule/schedule-page.component.html
+++ b/asobi-fe/asobi-project-fe/src/app/page/schedule/schedule-page.component.html
@@ -5,6 +5,8 @@
   [memoVisible]="isMemoVisible()"
   [calendarVisible]="isCalendarVisible()"
   [dateTime]="dateTime()"
+  [selectedTask]="selectedTask()"
+  [editingTask]="editingTask()"
   (openForm)="openForm()"
   (closeForm)="closeForm()"
   (openMemo)="openMemo()"
@@ -13,4 +15,8 @@
   (memoChange)="onMemoChange($event)"
   (openCalendar)="openCalendar()"
   (closeCalendar)="closeCalendar()"
-  (create)="onCreate($event)"></app-schedule-layout>
+  (save)="onSave($event)"
+  (taskSelect)="onTaskSelect($event)"
+  (taskClose)="closeTaskModal()"
+  (taskEdit)="onEditTask($event)"
+  (taskDelete)="onDeleteTask($event)"></app-schedule-layout>

--- a/asobi-fe/asobi-project-fe/src/app/page/schedule/schedule-page.component.ts
+++ b/asobi-fe/asobi-project-fe/src/app/page/schedule/schedule-page.component.ts
@@ -23,6 +23,8 @@ export class SchedulePageComponent implements OnInit {
   protected isCalendarVisible = signal(false);
   protected isMemoVisible = signal(false);
   protected dateTime = this.#clockService.now;
+  protected selectedTask = signal<Task | null>(null);
+  protected editingTask = signal<Task | null>(null);
 
   ngOnInit(): void {
     this.#scheduleService.load();
@@ -30,11 +32,13 @@ export class SchedulePageComponent implements OnInit {
   }
 
   openForm(): void {
+    this.editingTask.set(null);
     this.isFormVisible.set(true);
   }
 
   closeForm(): void {
     this.isFormVisible.set(false);
+    this.editingTask.set(null);
   }
 
   openCalendar(): void {
@@ -53,9 +57,33 @@ export class SchedulePageComponent implements OnInit {
     this.isMemoVisible.set(false);
   }
 
-  onCreate(task: Task): void {
-    this.#scheduleService.add(task);
+  onSave(task: Task): void {
+    if (this.editingTask()) {
+      this.#scheduleService.update(task);
+    } else {
+      this.#scheduleService.add(task);
+    }
     this.closeForm();
+    this.editingTask.set(null);
+  }
+
+  onTaskSelect(task: Task): void {
+    this.selectedTask.set(task);
+  }
+
+  closeTaskModal(): void {
+    this.selectedTask.set(null);
+  }
+
+  onEditTask(task: Task): void {
+    this.selectedTask.set(null);
+    this.editingTask.set(task);
+    this.isFormVisible.set(true);
+  }
+
+  onDeleteTask(id: string): void {
+    this.#scheduleService.remove(id);
+    this.closeTaskModal();
   }
 
   onMemoCreate(event: { text: string; x: number; y: number }): void {

--- a/asobi-fe/asobi-project-fe/src/app/view/layouts/schedule-layout/schedule-layout.component.html
+++ b/asobi-fe/asobi-project-fe/src/app/view/layouts/schedule-layout/schedule-layout.component.html
@@ -20,6 +20,7 @@
       [tasks]="tasks"
       [memos]="memos"
       (memoChange)="memoChange.emit($event)"
+      (taskSelect)="taskSelect.emit($event)"
     ></app-gantt-chart>
     @if (calendarVisible) {
       <app-calendar-modal
@@ -36,15 +37,24 @@
     @if (formVisible) {
       <div class="task-dialog" (click)="closeForm.emit()">
         <div class="dialog" (click)="$event.stopPropagation()">
-          <h2>タスク追加</h2>
+          <h2>{{ editingTask ? 'タスク編集' : 'タスク追加' }}</h2>
           <app-task-form
-            (save)="create.emit($event); closeForm.emit()"
+            [task]="editingTask"
+            (save)="save.emit($event); closeForm.emit()"
           ></app-task-form>
           <div class="actions">
             <button class="close" (click)="closeForm.emit()">閉じる</button>
           </div>
         </div>
       </div>
+    }
+    @if (selectedTask) {
+      <app-task-modal
+        [task]="selectedTask"
+        (edit)="taskEdit.emit($event)"
+        (delete)="taskDelete.emit($event)"
+        (close)="taskClose.emit()"
+      ></app-task-modal>
     }
   </div>
   <app-footer [dateTime]="dateTime"></app-footer>

--- a/asobi-fe/asobi-project-fe/src/app/view/layouts/schedule-layout/schedule-layout.component.ts
+++ b/asobi-fe/asobi-project-fe/src/app/view/layouts/schedule-layout/schedule-layout.component.ts
@@ -14,6 +14,7 @@ import { HeaderComponent } from '../../parts/header/header.component';
 import { FooterComponent } from '../../parts/footer/footer.component';
 import { CalendarModalComponent } from '../../parts/calendar-modal/calendar-modal.component';
 import { MemoModalComponent } from '../../parts/memo-modal/memo-modal.component';
+import { TaskModalComponent } from '../../parts/task-modal/task-modal.component';
 
 @Component({
   selector: 'app-schedule-layout',
@@ -25,6 +26,7 @@ import { MemoModalComponent } from '../../parts/memo-modal/memo-modal.component'
     FooterComponent,
     CalendarModalComponent,
     MemoModalComponent,
+    TaskModalComponent,
   ],
   changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: './schedule-layout.component.html',
@@ -39,7 +41,9 @@ export class ScheduleLayoutComponent {
   @Input() memoVisible = false;
   @Input() dateTime = '';
   @Input() calendarVisible = false;
-  @Output() create = new EventEmitter<Task>();
+  @Input() selectedTask: Task | null = null;
+  @Input() editingTask: Task | null = null;
+  @Output() save = new EventEmitter<Task>();
   @Output() openForm = new EventEmitter<void>();
   @Output() closeForm = new EventEmitter<void>();
   @Output() openMemo = new EventEmitter<void>();
@@ -48,6 +52,10 @@ export class ScheduleLayoutComponent {
   @Output() memoChange = new EventEmitter<Memo>();
   @Output() openCalendar = new EventEmitter<void>();
   @Output() closeCalendar = new EventEmitter<void>();
+  @Output() taskSelect = new EventEmitter<Task>();
+  @Output() taskEdit = new EventEmitter<Task>();
+  @Output() taskDelete = new EventEmitter<string>();
+  @Output() taskClose = new EventEmitter<void>();
 
   onCalendarConfirm(date: Date): void {
     this.ganttChart?.scrollToDate(date);

--- a/asobi-fe/asobi-project-fe/src/app/view/parts/gantt-chart/gantt-chart.component.html
+++ b/asobi-fe/asobi-project-fe/src/app/view/parts/gantt-chart/gantt-chart.component.html
@@ -38,12 +38,12 @@
         @for (row of emptyRows; track $index; let i = $index) {
           <tr>
             @if (tasks[i]; as task) {
-              <td class="sticky-left col-type">{{ task.type }}</td>
-              <td class="sticky-left col-name">{{ task.name }}</td>
-              <td class="sticky-left col-assignee">{{ task.assignee }}</td>
-              <td class="sticky-left col-start">{{ task.start | date : 'yyyy-MM-dd' }}</td>
-              <td class="sticky-left col-end">{{ task.end | date : 'yyyy-MM-dd' }}</td>
-              <td class="sticky-left col-progress">{{ task.progress }}%</td>
+              <td class="sticky-left col-type" (click)="taskSelect.emit(task)">{{ task.type }}</td>
+              <td class="sticky-left col-name" (click)="taskSelect.emit(task)">{{ task.name }}</td>
+              <td class="sticky-left col-assignee" (click)="taskSelect.emit(task)">{{ task.assignee }}</td>
+              <td class="sticky-left col-start" (click)="taskSelect.emit(task)">{{ task.start | date : 'yyyy-MM-dd' }}</td>
+              <td class="sticky-left col-end" (click)="taskSelect.emit(task)">{{ task.end | date : 'yyyy-MM-dd' }}</td>
+              <td class="sticky-left col-progress" (click)="taskSelect.emit(task)">{{ task.progress }}%</td>
 
               @for (date of dateRange; track date; let j = $index) {
                 <td

--- a/asobi-fe/asobi-project-fe/src/app/view/parts/gantt-chart/gantt-chart.component.ts
+++ b/asobi-fe/asobi-project-fe/src/app/view/parts/gantt-chart/gantt-chart.component.ts
@@ -29,6 +29,7 @@ export class GanttChartComponent implements AfterViewInit, OnChanges, OnDestroy 
   @Input({ required: true }) tasks: Task[] = [];
   @Input({ required: true }) memos: Memo[] = [];
   @Output() memoChange = new EventEmitter<Memo>();
+  @Output() taskSelect = new EventEmitter<Task>();
   @ViewChild('scrollHost') private scrollHost?: ElementRef<HTMLDivElement>;
 
   protected readonly emptyRows = Array.from({ length: 100 });
@@ -50,6 +51,7 @@ export class GanttChartComponent implements AfterViewInit, OnChanges, OnDestroy 
   };
   private onResizeMove = (e: MouseEvent) => this.handleResize(e);
   private onResizeUp = () => this.endResize();
+  private onHostScroll = () => this.handleHostScroll();
   private focusedCell?: { x: number; y: number };
   private focusedCellIdx?: { row: number; col: number };
   protected hoveredColIdx: number | null = null;
@@ -189,15 +191,19 @@ export class GanttChartComponent implements AfterViewInit, OnChanges, OnDestroy 
     const host = this.scrollHost?.nativeElement;
     if (!host) return;
 
-    host.addEventListener('scroll', () => {
-      if (host.scrollLeft + host.clientWidth >= host.scrollWidth - 100) {
-        this.extendRight(GanttChartComponent.EXTEND_DAYS);
-      } else if (host.scrollLeft <= 100) {
-        const prevWidth = host.scrollWidth;
-        this.extendLeft(GanttChartComponent.EXTEND_DAYS);
-        host.scrollLeft += host.scrollWidth - prevWidth;
-      }
-    });
+    host.addEventListener('scroll', this.onHostScroll);
+  }
+
+  private handleHostScroll(): void {
+    const host = this.scrollHost?.nativeElement;
+    if (!host) return;
+    if (host.scrollLeft + host.clientWidth >= host.scrollWidth - 100) {
+      this.extendRight(GanttChartComponent.EXTEND_DAYS);
+    } else if (host.scrollLeft <= 100) {
+      const prevWidth = host.scrollWidth;
+      this.extendLeft(GanttChartComponent.EXTEND_DAYS);
+      host.scrollLeft += host.scrollWidth - prevWidth;
+    }
   }
 
   onCellMouseDown(event: MouseEvent, rowIdx: number, colIdx: number): void {

--- a/asobi-fe/asobi-project-fe/src/app/view/parts/task-form/task-form.component.html
+++ b/asobi-fe/asobi-project-fe/src/app/view/parts/task-form/task-form.component.html
@@ -1,31 +1,31 @@
 <form (ngSubmit)="submit()" #f="ngForm">
   <div class="field">
     <label for="type">分類</label>
-    <input id="type" name="type" [(ngModel)]="task.type" />
+    <input id="type" name="type" [(ngModel)]="form.type" />
   </div>
   <div class="field">
     <label for="name">タスク名</label>
-    <input id="name" name="name" [(ngModel)]="task.name" required />
+    <input id="name" name="name" [(ngModel)]="form.name" required />
   </div>
   <div class="field">
     <label for="detail">詳細</label>
-    <textarea id="detail" name="detail" [(ngModel)]="task.detail"></textarea>
+    <textarea id="detail" name="detail" [(ngModel)]="form.detail"></textarea>
   </div>
   <div class="field">
     <label for="assignee">担当者</label>
-    <input id="assignee" name="assignee" [(ngModel)]="task.assignee" />
+    <input id="assignee" name="assignee" [(ngModel)]="form.assignee" />
   </div>
   <div class="field">
     <label for="start">開始日</label>
-    <input id="start" type="date" name="start" [(ngModel)]="task.start" />
+    <input id="start" type="date" name="start" [(ngModel)]="form.start" />
   </div>
   <div class="field">
     <label for="end">終了日</label>
-    <input id="end" type="date" name="end" [(ngModel)]="task.end" />
+    <input id="end" type="date" name="end" [(ngModel)]="form.end" />
   </div>
   <div class="field">
     <label for="progress">進捗(%)</label>
-    <input id="progress" type="number" name="progress" [(ngModel)]="task.progress" min="0" max="100" />
+    <input id="progress" type="number" name="progress" [(ngModel)]="form.progress" min="0" max="100" />
   </div>
   <div class="actions">
     <button type="submit" [disabled]="f.invalid">登録</button>

--- a/asobi-fe/asobi-project-fe/src/app/view/parts/task-form/task-form.component.ts
+++ b/asobi-fe/asobi-project-fe/src/app/view/parts/task-form/task-form.component.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectionStrategy, Component, EventEmitter, Output } from '@angular/core';
+import { ChangeDetectionStrategy, Component, EventEmitter, Input, Output } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import { Task } from '../../../domain/model/task';
 
@@ -11,29 +11,65 @@ import { Task } from '../../../domain/model/task';
   styleUrl: './task-form.component.scss'
 })
 export class TaskFormComponent {
-  protected task = {
+  private _task: Task | null = null;
+  protected form = {
     type: '',
     name: '',
     detail: '',
     assignee: '',
     start: '',
     end: '',
-    progress: 0
+    progress: 0,
   };
+
+  @Input()
+  set task(value: Task | null) {
+    this._task = value;
+    if (value) {
+      this.form = {
+        type: value.type,
+        name: value.name,
+        detail: value.detail,
+        assignee: value.assignee,
+        start: value.start.toISOString().split('T')[0],
+        end: value.end.toISOString().split('T')[0],
+        progress: value.progress,
+      };
+    } else {
+      this.reset();
+    }
+  }
+  get task(): Task | null {
+    return this._task;
+  }
 
   @Output() save = new EventEmitter<Task>();
 
   submit(): void {
+    const id = this._task?.id ?? crypto.randomUUID();
     this.save.emit({
-      id: crypto.randomUUID(),
-      type: this.task.type,
-      name: this.task.name,
-      detail: this.task.detail,
-      assignee: this.task.assignee,
-      start: new Date(this.task.start),
-      end: new Date(this.task.end),
-      progress: Number(this.task.progress)
+      id,
+      type: this.form.type,
+      name: this.form.name,
+      detail: this.form.detail,
+      assignee: this.form.assignee,
+      start: new Date(this.form.start),
+      end: new Date(this.form.end),
+      progress: Number(this.form.progress),
     });
-    this.task = { type: '', name: '', detail: '', assignee: '', start: '', end: '', progress: 0 };
+    this.reset();
+    this._task = null;
+  }
+
+  private reset(): void {
+    this.form = {
+      type: '',
+      name: '',
+      detail: '',
+      assignee: '',
+      start: '',
+      end: '',
+      progress: 0,
+    };
   }
 }

--- a/asobi-fe/asobi-project-fe/src/app/view/parts/task-modal/task-modal.component.html
+++ b/asobi-fe/asobi-project-fe/src/app/view/parts/task-modal/task-modal.component.html
@@ -1,0 +1,25 @@
+<div class="task-modal" (click)="close.emit()">
+  <div class="dialog" (click)="$event.stopPropagation()">
+    <button class="close-button" (click)="close.emit()">×</button>
+    <h2>タスク情報</h2>
+    <div class="content">
+      <div class="row"><span class="label">タスク分類</span><span class="value">{{ task.type }}</span></div>
+      <div class="row"><span class="label">タスク名</span><span class="value">{{ task.name }}</span></div>
+      <div class="row"><span class="label">タスク詳細</span><span class="value">{{ task.detail }}</span></div>
+      <div class="row"><span class="label">担当者</span><span class="value">{{ task.assignee }}</span></div>
+      <div class="row"><span class="label">開始日</span><span class="value">{{ task.start | date: 'yyyy-MM-dd' }}</span></div>
+      <div class="row"><span class="label">終了日</span><span class="value">{{ task.end | date: 'yyyy-MM-dd' }}</span></div>
+      <div class="row"><span class="label">進捗</span><span class="value">{{ task.progress }}%</span></div>
+    </div>
+    <div class="actions">
+      <button class="edit" (click)="edit.emit(task)">
+        <img src="edit.svg" alt="" class="icon" />
+        <span>編集</span>
+      </button>
+      <button class="delete" (click)="delete.emit(task.id)">
+        <img src="trash.svg" alt="" class="icon" />
+        <span>削除</span>
+      </button>
+    </div>
+  </div>
+</div>

--- a/asobi-fe/asobi-project-fe/src/app/view/parts/task-modal/task-modal.component.scss
+++ b/asobi-fe/asobi-project-fe/src/app/view/parts/task-modal/task-modal.component.scss
@@ -1,0 +1,84 @@
+.task-modal {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.4);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+}
+
+.task-modal .dialog {
+  background: #fff;
+  padding: 1.5rem 2rem;
+  border-radius: 8px;
+  width: 360px;
+  max-width: 90%;
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.2);
+  position: relative;
+}
+
+.close-button {
+  position: absolute;
+  top: -12px;
+  right: -12px;
+  width: 32px;
+  height: 32px;
+  border: none;
+  border-radius: 50%;
+  background: #e74c3c;
+  color: #fff;
+  font-size: 20px;
+  line-height: 32px;
+  cursor: pointer;
+}
+
+.content {
+  margin-top: 0.5rem;
+}
+
+.row {
+  display: flex;
+  margin-bottom: 0.5rem;
+}
+
+.label {
+  width: 80px;
+  font-weight: bold;
+  color: #555;
+}
+
+.value {
+  flex: 1;
+}
+
+.actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.5rem;
+  margin-top: 1rem;
+}
+
+.actions button {
+  display: flex;
+  align-items: center;
+  gap: 0.25rem;
+  border: none;
+  border-radius: 4px;
+  padding: 0.5rem 0.75rem;
+  cursor: pointer;
+  color: #fff;
+}
+
+.actions .edit {
+  background: #007bff;
+}
+
+.actions .delete {
+  background: #e74c3c;
+}
+
+.actions .icon {
+  width: 16px;
+  height: 16px;
+}

--- a/asobi-fe/asobi-project-fe/src/app/view/parts/task-modal/task-modal.component.ts
+++ b/asobi-fe/asobi-project-fe/src/app/view/parts/task-modal/task-modal.component.ts
@@ -1,0 +1,18 @@
+import { ChangeDetectionStrategy, Component, EventEmitter, Input, Output } from '@angular/core';
+import { DatePipe } from '@angular/common';
+import { Task } from '../../../domain/model/task';
+
+@Component({
+  selector: 'app-task-modal',
+  standalone: true,
+  imports: [DatePipe],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  templateUrl: './task-modal.component.html',
+  styleUrl: './task-modal.component.scss'
+})
+export class TaskModalComponent {
+  @Input({ required: true }) task!: Task;
+  @Output() edit = new EventEmitter<Task>();
+  @Output() delete = new EventEmitter<string>();
+  @Output() close = new EventEmitter<void>();
+}


### PR DESCRIPTION
## Summary
- タスク行クリックで詳細を表示するモーダルを実装
- モーダルからタスクの編集・削除に対応
- タスクフォームを編集対応に拡張

## Testing
- `npx ng test --watch=false --browsers=ChromeHeadless` (missing ChromeHeadless)
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689c20292a5c83318c21d276e993e6e7