### PR TITLE
feat: add task detail modal for tasks

### DIFF
--- a/asobi-fe/asobi-project-fe/public/delete.svg
+++ b/asobi-fe/asobi-project-fe/public/delete.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+  <path fill="#000" d="M3 6h18v2H3V6zm2 3h14l-1.4 14H6.4L5 9zm5 2v9h2v-9H8zm4 0v9h2v-9h-2zM9 4V2h6v2h5v2H4V4h5z"/>
+</svg>

--- a/asobi-fe/asobi-project-fe/src/app/page/schedule/schedule-page.component.html
+++ b/asobi-fe/asobi-project-fe/src/app/page/schedule/schedule-page.component.html
@@ -4,6 +4,9 @@
   [formVisible]="isFormVisible()"
   [memoVisible]="isMemoVisible()"
   [calendarVisible]="isCalendarVisible()"
+  [taskDetailVisible]="isTaskDetailVisible()"
+  [selectedTask]="selectedTask()"
+  [editingTask]="editingTask()"
   [dateTime]="dateTime()"
   (openForm)="openForm()"
   (closeForm)="closeForm()"
@@ -13,4 +16,8 @@
   (memoChange)="onMemoChange($event)"
   (openCalendar)="openCalendar()"
   (closeCalendar)="closeCalendar()"
-  (create)="onCreate($event)"></app-schedule-layout>
+  (create)="onSave($event)"
+  (openTaskDetail)="openTaskDetail($event)"
+  (closeTaskDetail)="closeTaskDetail()"
+  (editTask)="onEdit($event)"
+  (deleteTask)="onDelete($event)"></app-schedule-layout>

--- a/asobi-fe/asobi-project-fe/src/app/page/schedule/schedule-page.component.ts
+++ b/asobi-fe/asobi-project-fe/src/app/page/schedule/schedule-page.component.ts
@@ -22,6 +22,9 @@ export class SchedulePageComponent implements OnInit {
   protected isFormVisible = signal(false);
   protected isCalendarVisible = signal(false);
   protected isMemoVisible = signal(false);
+  protected isTaskDetailVisible = signal(false);
+  protected selectedTask = signal<Task | null>(null);
+  protected editingTask = signal<Task | null>(null);
   protected dateTime = this.#clockService.now;
 
   ngOnInit(): void {
@@ -30,6 +33,7 @@ export class SchedulePageComponent implements OnInit {
   }
 
   openForm(): void {
+    this.editingTask.set(null);
     this.isFormVisible.set(true);
   }
 
@@ -53,9 +57,14 @@ export class SchedulePageComponent implements OnInit {
     this.isMemoVisible.set(false);
   }
 
-  onCreate(task: Task): void {
-    this.#scheduleService.add(task);
+  onSave(task: Task): void {
+    if (this.editingTask()) {
+      this.#scheduleService.update(task);
+    } else {
+      this.#scheduleService.add(task);
+    }
     this.closeForm();
+    this.editingTask.set(null);
   }
 
   onMemoCreate(event: { text: string; x: number; y: number }): void {
@@ -73,5 +82,26 @@ export class SchedulePageComponent implements OnInit {
 
   onMemoChange(memo: Memo): void {
     this.#memoService.update(memo);
+  }
+
+  openTaskDetail(task: Task): void {
+    this.selectedTask.set(task);
+    this.isTaskDetailVisible.set(true);
+  }
+
+  closeTaskDetail(): void {
+    this.isTaskDetailVisible.set(false);
+    this.selectedTask.set(null);
+  }
+
+  onEdit(task: Task): void {
+    this.editingTask.set(task);
+    this.isFormVisible.set(true);
+    this.closeTaskDetail();
+  }
+
+  onDelete(id: string): void {
+    this.#scheduleService.remove(id);
+    this.closeTaskDetail();
   }
 }

--- a/asobi-fe/asobi-project-fe/src/app/view/layouts/schedule-layout/schedule-layout.component.html
+++ b/asobi-fe/asobi-project-fe/src/app/view/layouts/schedule-layout/schedule-layout.component.html
@@ -20,6 +20,7 @@
       [tasks]="tasks"
       [memos]="memos"
       (memoChange)="memoChange.emit($event)"
+      (taskClick)="openTaskDetail.emit($event)"
     ></app-gantt-chart>
     @if (calendarVisible) {
       <app-calendar-modal
@@ -38,6 +39,7 @@
         <div class="dialog" (click)="$event.stopPropagation()">
           <h2>タスク追加</h2>
           <app-task-form
+            [initialTask]="editingTask"
             (save)="create.emit($event); closeForm.emit()"
           ></app-task-form>
           <div class="actions">
@@ -45,6 +47,14 @@
           </div>
         </div>
       </div>
+    }
+    @if (taskDetailVisible && selectedTask) {
+      <app-task-detail-modal
+        [task]="selectedTask"
+        (close)="closeTaskDetail.emit()"
+        (edit)="editTask.emit($event)"
+        (delete)="deleteTask.emit($event)"
+      ></app-task-detail-modal>
     }
   </div>
   <app-footer [dateTime]="dateTime"></app-footer>

--- a/asobi-fe/asobi-project-fe/src/app/view/layouts/schedule-layout/schedule-layout.component.ts
+++ b/asobi-fe/asobi-project-fe/src/app/view/layouts/schedule-layout/schedule-layout.component.ts
@@ -14,6 +14,7 @@ import { HeaderComponent } from '../../parts/header/header.component';
 import { FooterComponent } from '../../parts/footer/footer.component';
 import { CalendarModalComponent } from '../../parts/calendar-modal/calendar-modal.component';
 import { MemoModalComponent } from '../../parts/memo-modal/memo-modal.component';
+import { TaskDetailModalComponent } from '../../parts/task-detail-modal/task-detail-modal.component';
 
 @Component({
   selector: 'app-schedule-layout',
@@ -25,6 +26,7 @@ import { MemoModalComponent } from '../../parts/memo-modal/memo-modal.component'
     FooterComponent,
     CalendarModalComponent,
     MemoModalComponent,
+    TaskDetailModalComponent,
   ],
   changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: './schedule-layout.component.html',
@@ -39,6 +41,9 @@ export class ScheduleLayoutComponent {
   @Input() memoVisible = false;
   @Input() dateTime = '';
   @Input() calendarVisible = false;
+  @Input() taskDetailVisible = false;
+  @Input() selectedTask: Task | null = null;
+  @Input() editingTask: Task | null = null;
   @Output() create = new EventEmitter<Task>();
   @Output() openForm = new EventEmitter<void>();
   @Output() closeForm = new EventEmitter<void>();
@@ -48,6 +53,10 @@ export class ScheduleLayoutComponent {
   @Output() memoChange = new EventEmitter<Memo>();
   @Output() openCalendar = new EventEmitter<void>();
   @Output() closeCalendar = new EventEmitter<void>();
+  @Output() openTaskDetail = new EventEmitter<Task>();
+  @Output() closeTaskDetail = new EventEmitter<void>();
+  @Output() editTask = new EventEmitter<Task>();
+  @Output() deleteTask = new EventEmitter<string>();
 
   onCalendarConfirm(date: Date): void {
     this.ganttChart?.scrollToDate(date);

--- a/asobi-fe/asobi-project-fe/src/app/view/parts/gantt-chart/gantt-chart.component.html
+++ b/asobi-fe/asobi-project-fe/src/app/view/parts/gantt-chart/gantt-chart.component.html
@@ -40,8 +40,8 @@
     <table class="gantt-table">
       <tbody>
         @for (row of emptyRows; track $index; let i = $index) {
-          <tr>
-            @if (tasks[i]; as task) {
+          @if (tasks[i]; as task) {
+            <tr (click)="onRowClick(task)">
               <td class="sticky-left col-type">{{ task.type }}</td>
               <td class="sticky-left col-name">{{ task.name }}</td>
               <td class="sticky-left col-assignee">{{ task.assignee }}</td>
@@ -66,7 +66,9 @@
                   [class.month-boundary]="isMonthStart(date) && j !== 0"
                 ></td>
               }
-            } @else {
+            </tr>
+          } @else {
+            <tr>
               <td class="sticky-left col-type"></td>
               <td class="sticky-left col-name"></td>
               <td class="sticky-left col-assignee"></td>
@@ -85,8 +87,8 @@
                   [class.month-boundary]="isMonthStart(date) && j !== 0"
                 ></td>
               }
-            }
-          </tr>
+            </tr>
+          }
         }
       </tbody>
     </table>

--- a/asobi-fe/asobi-project-fe/src/app/view/parts/gantt-chart/gantt-chart.component.ts
+++ b/asobi-fe/asobi-project-fe/src/app/view/parts/gantt-chart/gantt-chart.component.ts
@@ -29,6 +29,7 @@ export class GanttChartComponent implements AfterViewInit, OnChanges{
   @Input({ required: true }) tasks: Task[] = [];
   @Input({ required: true }) memos: Memo[] = [];
   @Output() memoChange = new EventEmitter<Memo>();
+  @Output() taskClick = new EventEmitter<Task>();
   @ViewChild('scrollHost') private scrollHost?: ElementRef<HTMLDivElement>;
   @ViewChild('headerHost') private headerHost?: ElementRef<HTMLDivElement>;
 
@@ -356,6 +357,10 @@ export class GanttChartComponent implements AfterViewInit, OnChanges{
 
   private getMemoBodyText(el: HTMLElement): string {
     return el.querySelector<HTMLElement>('.memo-body')?.innerText ?? '';
+  }
+
+  onRowClick(task: Task): void {
+    this.taskClick.emit(task);
   }
 
   private getStickyWidth(): number {

--- a/asobi-fe/asobi-project-fe/src/app/view/parts/task-detail-modal/task-detail-modal.component.html
+++ b/asobi-fe/asobi-project-fe/src/app/view/parts/task-detail-modal/task-detail-modal.component.html
@@ -1,0 +1,25 @@
+<div class="task-detail-modal" (click)="close.emit()">
+  <div class="dialog" (click)="$event.stopPropagation()">
+    <button class="close-btn" (click)="close.emit()">×</button>
+    <h2>タスク詳細</h2>
+    <div class="content">
+      <p><span class="label">分類:</span> {{ task.type }}</p>
+      <p><span class="label">タスク名:</span> {{ task.name }}</p>
+      <p><span class="label">詳細:</span> {{ task.detail }}</p>
+      <p><span class="label">担当者:</span> {{ task.assignee }}</p>
+      <p><span class="label">開始日:</span> {{ task.start | date : 'yyyy-MM-dd' }}</p>
+      <p><span class="label">終了日:</span> {{ task.end | date : 'yyyy-MM-dd' }}</p>
+      <p><span class="label">進捗:</span> {{ task.progress }}%</p>
+    </div>
+    <div class="actions">
+      <button class="edit-btn" (click)="onEdit()">
+        <img src="edit.svg" alt="" class="icon" />
+        <span>編集</span>
+      </button>
+      <button class="delete-btn" (click)="onDelete()">
+        <img src="delete.svg" alt="" class="icon" />
+        <span>削除</span>
+      </button>
+    </div>
+  </div>
+</div>

--- a/asobi-fe/asobi-project-fe/src/app/view/parts/task-detail-modal/task-detail-modal.component.scss
+++ b/asobi-fe/asobi-project-fe/src/app/view/parts/task-detail-modal/task-detail-modal.component.scss
@@ -1,0 +1,75 @@
+.task-detail-modal {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.4);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+}
+
+.task-detail-modal .dialog {
+  position: relative;
+  background: #fff;
+  padding: 2rem;
+  border-radius: 8px;
+  width: 400px;
+  max-width: 90%;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+}
+
+.task-detail-modal .close-btn {
+  position: absolute;
+  top: 0.5rem;
+  right: 0.5rem;
+  background: #f44336;
+  color: #fff;
+  border: none;
+  border-radius: 50%;
+  width: 24px;
+  height: 24px;
+  line-height: 24px;
+  text-align: center;
+  cursor: pointer;
+}
+
+.task-detail-modal .content p {
+  margin: 0.5rem 0;
+}
+
+.task-detail-modal .label {
+  font-weight: bold;
+  margin-right: 0.5rem;
+}
+
+.task-detail-modal .actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 1rem;
+  margin-top: 1.5rem;
+}
+
+.task-detail-modal .actions button {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.5rem 1rem;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+}
+
+.task-detail-modal .actions .edit-btn {
+  background: #1976d2;
+  color: #fff;
+}
+
+.task-detail-modal .actions .delete-btn {
+  background: #e53935;
+  color: #fff;
+}
+
+.task-detail-modal .actions .icon {
+  width: 16px;
+  height: 16px;
+}

--- a/asobi-fe/asobi-project-fe/src/app/view/parts/task-detail-modal/task-detail-modal.component.ts
+++ b/asobi-fe/asobi-project-fe/src/app/view/parts/task-detail-modal/task-detail-modal.component.ts
@@ -1,0 +1,26 @@
+import { ChangeDetectionStrategy, Component, EventEmitter, Input, Output } from '@angular/core';
+import { DatePipe } from '@angular/common';
+import { Task } from '../../../domain/model/task';
+
+@Component({
+  selector: 'app-task-detail-modal',
+  standalone: true,
+  imports: [DatePipe],
+  templateUrl: './task-detail-modal.component.html',
+  styleUrl: './task-detail-modal.component.scss',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class TaskDetailModalComponent {
+  @Input({ required: true }) task!: Task;
+  @Output() edit = new EventEmitter<Task>();
+  @Output() delete = new EventEmitter<string>();
+  @Output() close = new EventEmitter<void>();
+
+  onEdit(): void {
+    this.edit.emit(this.task);
+  }
+
+  onDelete(): void {
+    this.delete.emit(this.task.id);
+  }
+}

--- a/asobi-fe/asobi-project-fe/src/app/view/parts/task-form/task-form.component.ts
+++ b/asobi-fe/asobi-project-fe/src/app/view/parts/task-form/task-form.component.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectionStrategy, Component, EventEmitter, Output } from '@angular/core';
+import { ChangeDetectionStrategy, Component, EventEmitter, Input, Output } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import { Task } from '../../../domain/model/task';
 
@@ -11,29 +11,74 @@ import { Task } from '../../../domain/model/task';
   styleUrl: './task-form.component.scss'
 })
 export class TaskFormComponent {
-  protected task = {
+  protected task: {
+    id?: string;
+    type: string;
+    name: string;
+    detail: string;
+    assignee: string;
+    start: string;
+    end: string;
+    progress: number;
+  } = {
+    id: undefined,
     type: '',
     name: '',
     detail: '',
     assignee: '',
     start: '',
     end: '',
-    progress: 0
+    progress: 0,
   };
+
+  @Input()
+  set initialTask(value: Task | null) {
+    if (value) {
+      this.task = {
+        id: value.id,
+        type: value.type,
+        name: value.name,
+        detail: value.detail,
+        assignee: value.assignee,
+        start: this.formatDate(value.start),
+        end: this.formatDate(value.end),
+        progress: value.progress,
+      };
+    } else {
+      this.reset();
+    }
+  }
 
   @Output() save = new EventEmitter<Task>();
 
   submit(): void {
     this.save.emit({
-      id: crypto.randomUUID(),
+      id: this.task.id ?? crypto.randomUUID(),
       type: this.task.type,
       name: this.task.name,
       detail: this.task.detail,
       assignee: this.task.assignee,
       start: new Date(this.task.start),
       end: new Date(this.task.end),
-      progress: Number(this.task.progress)
+      progress: Number(this.task.progress),
     });
-    this.task = { type: '', name: '', detail: '', assignee: '', start: '', end: '', progress: 0 };
+    this.reset();
+  }
+
+  private reset(): void {
+    this.task = {
+      id: undefined,
+      type: '',
+      name: '',
+      detail: '',
+      assignee: '',
+      start: '',
+      end: '',
+      progress: 0,
+    };
+  }
+
+  private formatDate(date: Date): string {
+    return date.toISOString().substring(0, 10);
   }
 }


### PR DESCRIPTION
## Summary
- add task detail modal component with edit/delete actions
- emit task click from gantt chart to open detail modal
- support editing existing tasks in task form

## Testing
- `npm test` *(fails: No binary for Chrome browser)*

------
https://chatgpt.com/codex/tasks/task_e_689c24d0598883318d744a1318b618d8