### PR TITLE
fix: adjust task detail modal button styles

### DIFF
--- a/asobi-fe/asobi-project-fe/src/app/view/parts/task-detail-modal/task-detail-modal.component.html
+++ b/asobi-fe/asobi-project-fe/src/app/view/parts/task-detail-modal/task-detail-modal.component.html
@@ -1,14 +1,20 @@
 <div class="task-detail-modal" (click)="close.emit()">
   <div class="dialog" (click)="$event.stopPropagation()">
-    <button class="close-btn" (click)="close.emit()">×</button>
+    <button class="close-btn" (click)="close.emit()">
+      <img src="add.svg" alt="閉じる" class="close-icon" />
+    </button>
     <h2>タスク詳細</h2>
     <div class="content">
       <p><span class="label">分類:</span> {{ task.type }}</p>
       <p><span class="label">タスク名:</span> {{ task.name }}</p>
       <p><span class="label">詳細:</span> {{ task.detail }}</p>
       <p><span class="label">担当者:</span> {{ task.assignee }}</p>
-      <p><span class="label">開始日:</span> {{ task.start | date : 'yyyy-MM-dd' }}</p>
-      <p><span class="label">終了日:</span> {{ task.end | date : 'yyyy-MM-dd' }}</p>
+      <p>
+        <span class="label">開始日:</span> {{ task.start | date: "yyyy-MM-dd" }}
+      </p>
+      <p>
+        <span class="label">終了日:</span> {{ task.end | date: "yyyy-MM-dd" }}
+      </p>
       <p><span class="label">進捗:</span> {{ task.progress }}%</p>
     </div>
     <div class="actions">

--- a/asobi-fe/asobi-project-fe/src/app/view/parts/task-detail-modal/task-detail-modal.component.scss
+++ b/asobi-fe/asobi-project-fe/src/app/view/parts/task-detail-modal/task-detail-modal.component.scss
@@ -22,15 +22,22 @@
   position: absolute;
   top: 0.5rem;
   right: 0.5rem;
-  background: #f44336;
+  background: #d32f2f;
   color: #fff;
   border: none;
   border-radius: 50%;
   width: 24px;
   height: 24px;
-  line-height: 24px;
-  text-align: center;
+  display: flex;
+  align-items: center;
+  justify-content: center;
   cursor: pointer;
+}
+
+.task-detail-modal .close-btn .close-icon {
+  width: 16px;
+  height: 16px;
+  transform: rotate(45deg);
 }
 
 .task-detail-modal .content p {
@@ -60,12 +67,12 @@
 }
 
 .task-detail-modal .actions .edit-btn {
-  background: #1976d2;
+  background: #546e7a;
   color: #fff;
 }
 
 .task-detail-modal .actions .delete-btn {
-  background: #e53935;
+  background: #b71c1c;
   color: #fff;
 }
 


### PR DESCRIPTION
## Summary
- タスク詳細モーダルの閉じるボタンをプラスアイコンに変更し色を落ち着いた赤に調整
- 編集・削除ボタンのカラーリングを落ち着いた色味に変更

## Testing
- `CHROME_BIN=chromium-browser npm test -- --watch=false --browsers=ChromeHeadless` *(Chromiumがsnap依存のため起動失敗)*

------
https://chatgpt.com/codex/tasks/task_e_689c2b65b5a083319354b3e590db6151