### PR TITLE
fix: ガントチャートの横スクロール挙動の改善

### DIFF
--- a/asobi-fe/asobi-project-fe/src/app/view/parts/gantt-chart/gantt-chart.component.scss
+++ b/asobi-fe/asobi-project-fe/src/app/view/parts/gantt-chart/gantt-chart.component.scss
@@ -61,13 +61,14 @@
   height: var(--scrollbar-h);
   width: calc(100% - var(--left-cols-width));
   margin-left: var(--left-cols-width);
-  overflow-x: auto;
+  overflow-x: scroll;
   overflow-y: hidden;
   position: relative;
   background: #f3f4f6;
   border-top: 1px solid #e5e7eb;
   scrollbar-color: #9ca3af transparent;
   scrollbar-width: thin;
+  scrollbar-gutter: stable;
 }
 
 .h-scrollbar-inner {

--- a/asobi-fe/asobi-project-fe/src/app/view/parts/gantt-chart/gantt-chart.component.ts
+++ b/asobi-fe/asobi-project-fe/src/app/view/parts/gantt-chart/gantt-chart.component.ts
@@ -165,7 +165,10 @@ export class GanttChartComponent
     if (header)
       header.addEventListener('wheel', this.onWheel, { passive: false });
     const bar = this.hScrollbar?.nativeElement;
-    if (bar) bar.addEventListener('scroll', this.onHScroll);
+    if (bar) {
+      bar.addEventListener('scroll', this.onHScroll);
+      bar.addEventListener('wheel', this.onWheel, { passive: false });
+    }
     this.updateScrollbarWidth();
     this.onHostScroll();
   }
@@ -179,7 +182,10 @@ export class GanttChartComponent
     const header = this.headerHost?.nativeElement;
     if (header) header.removeEventListener('wheel', this.onWheel);
     const bar = this.hScrollbar?.nativeElement;
-    if (bar) bar.removeEventListener('scroll', this.onHScroll);
+    if (bar) {
+      bar.removeEventListener('scroll', this.onHScroll);
+      bar.removeEventListener('wheel', this.onWheel);
+    }
   }
 
   ngOnChanges(changes: SimpleChanges): void {
@@ -269,6 +275,7 @@ export class GanttChartComponent
     if (delta !== 0) {
       host.scrollLeft += delta;
       event.preventDefault();
+      event.stopPropagation();
     }
   };
 


### PR DESCRIPTION
## Summary
- ガントチャートの横スクロールバーを常に表示
- 横スクロール時にページ全体が反応しないようホイールイベントを抑止

## Testing
- `npm test -- --watch=false --browsers=ChromeHeadless` (⚠️ Chrome がないため実行不可)
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_689c845a1ec083319ae2e6e5bc72829e