### PR TITLE
ガントチャートの横スクロールを再設計

### DIFF
--- a/asobi-fe/asobi-project-fe/src/app/view/parts/gantt-chart/gantt-chart.component.scss
+++ b/asobi-fe/asobi-project-fe/src/app/view/parts/gantt-chart/gantt-chart.component.scss
@@ -41,15 +41,20 @@
   width: 100%;
   height: calc(100% - var(--head-total) - var(--scrollbar-h));
   overflow-y: auto;
-  overflow-x: hidden;
+  overflow-x: auto;
   position: relative;
   scrollbar-gutter: stable;
   overscroll-behavior: contain;
+  scrollbar-width: none;
+}
+
+.scroll-host::-webkit-scrollbar {
+  display: none;
 }
 
 .header-wrapper {
   height: var(--head-total);
-  overflow-x: scroll;
+  overflow-x: hidden;
   overflow-y: hidden;
   scrollbar-width: none;
   flex: none;


### PR DESCRIPTION
## 概要
- ガントチャートの横スクロール処理を刷新
- 表示範囲を今日から前後3ヶ月に統一し、端1ヶ月で2ヶ月分を動的取得
- スクロールバーを日付列のみに表示するようスタイル調整

## テスト
- `npm test` (Chrome が無いため失敗)

------
https://chatgpt.com/codex/tasks/task_e_689c962e5338833198d2f803ffddbb8f