### PR TITLE
ガントチャートの表示期間を1年に拡大

### DIFF
--- a/asobi-fe/asobi-project-fe/src/app/view/parts/gantt-chart/gantt-chart.component.ts
+++ b/asobi-fe/asobi-project-fe/src/app/view/parts/gantt-chart/gantt-chart.component.ts
@@ -52,7 +52,7 @@ export class GanttChartComponent
   protected taskViews: TaskView[] = [];
   private rangeStart: Date;
   private rangeEnd: Date;
-  private static readonly INITIAL_MONTHS = 3;
+  private static readonly INITIAL_MONTHS = 6;
   private static readonly EXTEND_MONTHS = 2;
   private static readonly EXTEND_THRESHOLD_DAYS = 30;
   private static readonly CELL_WIDTH = 36;


### PR DESCRIPTION
## 概要
- ガントチャートの初期表示期間を前後6ヶ月に変更

## テスト
- `npm test -- --watch=false --browsers=ChromeHeadless` (ChromeHeadlessが見つからず失敗)


------
https://chatgpt.com/codex/tasks/task_e_689c9c95c7d88331b3d4d2c075ff5162