### PR TITLE
ガントチャート固定列のソート・フィルタ機能を追加

### DIFF
--- a/asobi-fe/asobi-project-fe/public/sort.svg
+++ b/asobi-fe/asobi-project-fe/public/sort.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+  <path d="M3 4h18l-7 8v6l-4 2v-8z" fill="#000"/>
+</svg>

--- a/asobi-fe/asobi-project-fe/src/app/view/parts/gantt-chart/gantt-chart.component.html
+++ b/asobi-fe/asobi-project-fe/src/app/view/parts/gantt-chart/gantt-chart.component.html
@@ -1,12 +1,99 @@
-<div class="gantt-container">
+<div class="gantt-container" (click)="closeFilterPopup()">
   <div class="header-wrapper" #headerHost>
     <table class="gantt-table">
       <thead>
         <!-- 1行目：左6列は実際に rowspan=2（タスクヘッダーは1セルで2行分） -->
         <tr class="head-1">
-          <th class="h sticky-left col-type" rowspan="2">タスク分類</th>
-          <th class="h sticky-left col-name" rowspan="2">タスク名</th>
-          <th class="h sticky-left col-assignee" rowspan="2">担当者</th>
+          <th class="h sticky-left col-type" rowspan="2">
+            <span>タスク分類</span>
+            <img
+              src="sort.svg"
+              alt="ソート"
+              class="sort-icon"
+              (click)="toggleFilterPopup('type', $event)"
+            />
+            @if (filterPopup === 'type') {
+              <div class="filter-popup" (click)="$event.stopPropagation()">
+                <input
+                  type="text"
+                  class="filter-input"
+                  [(ngModel)]="filters.type.keyword"
+                />
+                <div class="options">
+                  @for (opt of getFilteredOptions('type'); track opt) {
+                    <label>
+                      <input
+                        type="checkbox"
+                        [checked]="filters.type.selected.has(opt)"
+                        (change)="onFilterChange('type', opt, $event.target.checked)"
+                      />
+                      {{ opt }}
+                    </label>
+                  }
+                </div>
+              </div>
+            }
+          </th>
+          <th class="h sticky-left col-name" rowspan="2">
+            <span>タスク名</span>
+            <img
+              src="sort.svg"
+              alt="ソート"
+              class="sort-icon"
+              (click)="toggleFilterPopup('name', $event)"
+            />
+            @if (filterPopup === 'name') {
+              <div class="filter-popup" (click)="$event.stopPropagation()">
+                <input
+                  type="text"
+                  class="filter-input"
+                  [(ngModel)]="filters.name.keyword"
+                />
+                <div class="options">
+                  @for (opt of getFilteredOptions('name'); track opt) {
+                    <label>
+                      <input
+                        type="checkbox"
+                        [checked]="filters.name.selected.has(opt)"
+                        (change)="onFilterChange('name', opt, $event.target.checked)"
+                      />
+                      {{ opt }}
+                    </label>
+                  }
+                </div>
+              </div>
+            }
+          </th>
+          <th class="h sticky-left col-assignee" rowspan="2">
+            <span>担当者</span>
+            <img
+              src="sort.svg"
+              alt="ソート"
+              class="sort-icon"
+              (click)="toggleFilterPopup('assignee', $event)"
+            />
+            @if (filterPopup === 'assignee') {
+              <div class="filter-popup" (click)="$event.stopPropagation()">
+                <input
+                  type="text"
+                  class="filter-input"
+                  [(ngModel)]="filters.assignee.keyword"
+                />
+                <div class="options">
+                  @for (opt of getFilteredOptions('assignee'); track opt) {
+                    <label>
+                      <input
+                        type="checkbox"
+                        [checked]="filters.assignee.selected.has(opt)"
+                        (change)="onFilterChange('assignee', opt, $event.target.checked)"
+                      />
+                      {{ opt }}
+                    </label>
+                  }
+                </div>
+              </div>
+            }
+          </th>
           <th class="h sticky-left col-start" rowspan="2">開始日</th>
           <th class="h sticky-left col-end" rowspan="2">終了日</th>
           <th class="h sticky-left col-progress" rowspan="2">進捗率</th>

--- a/asobi-fe/asobi-project-fe/src/app/view/parts/gantt-chart/gantt-chart.component.scss
+++ b/asobi-fe/asobi-project-fe/src/app/view/parts/gantt-chart/gantt-chart.component.scss
@@ -114,6 +114,45 @@
   box-sizing: border-box;
 }
 
+th.col-type,
+th.col-name,
+th.col-assignee {
+  position: relative;
+}
+
+.sort-icon {
+  width: 16px;
+  height: 16px;
+  margin-left: 4px;
+  cursor: pointer;
+}
+
+.filter-popup {
+  position: absolute;
+  top: 100%;
+  left: 0;
+  background: #fff;
+  border: 1px solid #d1d5db;
+  border-radius: 4px;
+  padding: 8px;
+  z-index: 10;
+  max-height: 200px;
+  overflow: auto;
+  text-align: left;
+}
+
+.filter-input {
+  width: 100%;
+  margin-bottom: 4px;
+  box-sizing: border-box;
+}
+
+.filter-popup .options {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
 /* ---------------- ヘッダー固定（2行） ---------------- */
 /* ---------------- ヘッダー ---------------- */
 .gantt-table thead .h {


### PR DESCRIPTION
## 概要
- タスク分類・タスク名・担当者列にソートアイコンとポップアップを追加
- 前方一致検索とマルチ選択によるフィルタ機能を実装

## テスト
- `npm test -- --watch=false --browsers=ChromeHeadless` ※ChromeHeadlessが見つからず失敗

------
https://chatgpt.com/codex/tasks/task_e_689c9f9548d88331bae7a389e6e0ecb9