### PR TITLE
fix: ガントチャートのヘッダーとボディのスクロール同期

### DIFF
--- a/asobi-fe/asobi-project-fe/src/app/view/parts/gantt-chart/gantt-chart.component.ts
+++ b/asobi-fe/asobi-project-fe/src/app/view/parts/gantt-chart/gantt-chart.component.ts
@@ -213,6 +213,7 @@ export class GanttChartComponent
       const stickyWidth = this.getStickyWidth();
       if (th) host.scrollLeft = Math.max(th.offsetLeft - stickyWidth, 0);
       this.updateScrollbarThumb();
+      this.syncHeader();
     });
   }
 
@@ -221,10 +222,9 @@ export class GanttChartComponent
   }
 
   private onHostScroll = (): void => {
+    this.syncHeader();
     const host = this.scrollHost?.nativeElement;
-    const header = this.headerHost?.nativeElement;
     if (!host) return;
-    if (header) header.scrollLeft = host.scrollLeft;
     this.updateScrollbarThumb();
     const stickyWidth = this.getStickyWidth();
     const scrollLeft = host.scrollLeft;
@@ -244,6 +244,14 @@ export class GanttChartComponent
       this.extendLeftMonths(GanttChartComponent.EXTEND_MONTHS);
     }
   };
+
+  private syncHeader(): void {
+    const host = this.scrollHost?.nativeElement;
+    const header = this.headerHost?.nativeElement;
+    if (!host || !header) return;
+    header.scrollLeft = host.scrollLeft;
+    header.style.width = `${host.clientWidth}px`;
+  }
 
   onCellMouseDown(event: MouseEvent, rowIdx: number, colIdx: number): void {
     const host = this.scrollHost?.nativeElement;


### PR DESCRIPTION
## Summary
- ヘッダー横スクロール位置と幅をボディに同期させ、スクロール時のズレを解消

## Testing
- `CHROME_BIN=chromium-browser npm test -- --watch=false` (chromium snap 未導入のため失敗)

------
https://chatgpt.com/codex/tasks/task_e_689ca0ed707883318f9eded0be9f766e