### PR TITLE
修正: GanttChartComponent のマージミスを解消

### DIFF
--- a/asobi-fe/asobi-project-fe/src/app/view/parts/gantt-chart/gantt-chart.component.ts
+++ b/asobi-fe/asobi-project-fe/src/app/view/parts/gantt-chart/gantt-chart.component.ts
@@ -28,11 +28,6 @@ import {
 import { Task } from '../../../domain/model/task';
 import { Memo } from '../../../domain/model/memo';
 import { MemoComponent } from '../memo/memo.component';
-import {
-  ScrollAnchor,
-  captureAnchor,
-  restoreFromAnchor,
-} from './gantt-scroll-anchor.util';
 
 interface TaskView {
   task: Task;
@@ -355,9 +350,8 @@ export class GanttChartComponent
       )
         this.needsPrune = true;
     }
-  }
 
-  onCellMouseDown(event: MouseEvent, rowIdx: number, colIdx: number): void {
+    onCellMouseDown(event: MouseEvent, rowIdx: number, colIdx: number): void {
     const host = this.scrollHost?.nativeElement;
     const cell = event.currentTarget as HTMLElement | null;
     if (!host || !cell) return;


### PR DESCRIPTION
## 概要
- GanttChartComponent の余分な閉じカッコを削除し、クラス構造を修正
- 重複していた ScrollAnchor 関連の import を整理

## テスト
- `npx tsc -p tsconfig.app.json --pretty false --noEmit --incremental false`
- `npm run build`
- `npm test` (Chrome が無いため失敗)


------
https://chatgpt.com/codex/tasks/task_e_689cc7bc934483319d734fbaa39039c8