### PR TITLE
ガントチャートのスパン移動を追加

### DIFF
--- a/asobi-fe/asobi-project-fe/public/arrow-left.svg
+++ b/asobi-fe/asobi-project-fe/public/arrow-left.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="#000" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <polyline points="15 18 9 12 15 6"/>
+</svg>

--- a/asobi-fe/asobi-project-fe/public/arrow-right.svg
+++ b/asobi-fe/asobi-project-fe/public/arrow-right.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="#000" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <polyline points="9 6 15 12 9 18"/>
+</svg>

--- a/asobi-fe/asobi-project-fe/src/app/view/parts/gantt-chart/gantt-chart.component.html
+++ b/asobi-fe/asobi-project-fe/src/app/view/parts/gantt-chart/gantt-chart.component.html
@@ -206,11 +206,20 @@
       }
     </div>
   </div>
-  <div
-    class="h-scrollbar"
-    #hScrollbar
-    (mousedown)="onScrollbarMouseDown($event)"
-  >
-    <div class="h-scrollbar-thumb" #hScrollbarThumb></div>
+  <div class="h-scrollbar-wrapper">
+    <div class="left-space"></div>
+    <button class="span-nav prev" (click)="moveSpan(-1)">
+      <img src="arrow-left.svg" alt="前の期間" />
+    </button>
+    <div
+      class="h-scrollbar"
+      #hScrollbar
+      (mousedown)="onScrollbarMouseDown($event)"
+    >
+      <div class="h-scrollbar-thumb" #hScrollbarThumb></div>
+    </div>
+    <button class="span-nav next" (click)="moveSpan(1)">
+      <img src="arrow-right.svg" alt="次の期間" />
+    </button>
   </div>
 </div>

--- a/asobi-fe/asobi-project-fe/src/app/view/parts/gantt-chart/gantt-chart.component.scss
+++ b/asobi-fe/asobi-project-fe/src/app/view/parts/gantt-chart/gantt-chart.component.scss
@@ -54,24 +54,41 @@
   display: none;
 }
 
-.h-scrollbar {
+
+.h-scrollbar-wrapper {
   height: var(--scrollbar-h);
-  width: calc(100% - var(--left-cols-width));
-  margin-left: var(--left-cols-width);
-  position: relative;
+  width: 100%;
+  display: flex;
   background: #f3f4f6;
   border-top: 1px solid #e5e7eb;
 }
 
-.h-scrollbar::before {
-  content: "";
-  position: absolute;
-  top: -1px;
-  bottom: 0;
-  left: calc(-1 * var(--left-cols-width));
+.left-space {
   width: var(--left-cols-width);
+  height: 100%;
   background: inherit;
-  border-top: 1px solid #e5e7eb;
+}
+
+.span-nav {
+  width: var(--scrollbar-h);
+  height: 100%;
+  background: inherit;
+  border: none;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.span-nav img {
+  width: 12px;
+  height: 12px;
+}
+
+.h-scrollbar {
+  flex: 1;
+  position: relative;
+  background: inherit;
 }
 
 .h-scrollbar-thumb {


### PR DESCRIPTION
## 概要
- ガントチャートの表示範囲を「過去6ヶ月〜未来1年」のスパンに固定
- スクロールバー左右にスパン移動ボタンを設置
- スクロールイベントのハンドリングを最適化

## テスト
- `npm test` (Chrome が見つからず失敗)


------
https://chatgpt.com/codex/tasks/task_e_689d45a6663c833187d3d4e137221d8b