### PR TITLE
feat: speed up gantt scroll rendering

### DIFF
--- a/asobi-fe/asobi-project-fe/src/app/view/parts/gantt-chart/gantt-chart.component.scss
+++ b/asobi-fe/asobi-project-fe/src/app/view/parts/gantt-chart/gantt-chart.component.scss
@@ -47,7 +47,9 @@
   scrollbar-gutter: stable;
   overscroll-behavior: contain;
   scrollbar-width: none;
-  scroll-behavior: smooth;
+  /* レンダリング遅延を抑えるためにGPUコンポジットを有効化 */
+  transform: translateZ(0);
+  will-change: scroll-position;
 }
 
 .scroll-host::-webkit-scrollbar {

--- a/asobi-fe/asobi-project-fe/src/app/view/parts/gantt-chart/gantt-chart.component.ts
+++ b/asobi-fe/asobi-project-fe/src/app/view/parts/gantt-chart/gantt-chart.component.ts
@@ -317,8 +317,7 @@ export class GanttChartComponent
         `.head-2 th[data-idx="${idx}"]`,
       );
       const stickyWidth = this.getStickyWidth();
-      if (th)
-        host.scrollTo({ left: Math.max(th.offsetLeft - stickyWidth, 0) });
+      if (th) host.scrollLeft = Math.max(th.offsetLeft - stickyWidth, 0);
       this.updateScrollbarThumb();
     });
   }


### PR DESCRIPTION
## Summary
- improve scroll performance by enabling GPU compositing on the scroll host
- snap initial position to today's column beside sticky fields

## Testing
- `npm test` *(fails: No binary for Chrome browser on your platform)*

------
https://chatgpt.com/codex/tasks/task_e_689d4dce03388331860af46ca46636cc