### PR TITLE
feat: enable progress input from schedule cells

### DIFF
--- a/asobi-fe/asobi-project-fe/src/app/domain/service/impl/schedule.service.impl.ts
+++ b/asobi-fe/asobi-project-fe/src/app/domain/service/impl/schedule.service.impl.ts
@@ -29,4 +29,13 @@ export class ScheduleService implements ScheduleServiceInterface {
     await this.#repository.delete(id);
     this.#state.remove(id);
   }
+
+  async addProgress(id: string, value: number): Promise<void> {
+    const task = this.#state.tasks().find(t => t.id === id);
+    if (!task) return;
+    const progress = Math.min(task.progress + value, 100);
+    const updated: Task = { ...task, progress };
+    await this.#repository.update(updated);
+    this.#state.update(updated);
+  }
 }

--- a/asobi-fe/asobi-project-fe/src/app/domain/service/interface/schedule.service.ts
+++ b/asobi-fe/asobi-project-fe/src/app/domain/service/interface/schedule.service.ts
@@ -7,4 +7,5 @@ export interface ScheduleServiceInterface {
   add(task: Task): Promise<void>;
   update(task: Task): Promise<void>;
   remove(id: string): Promise<void>;
+  addProgress(id: string, value: number): Promise<void>;
 }

--- a/asobi-fe/asobi-project-fe/src/app/page/schedule/schedule-page.component.html
+++ b/asobi-fe/asobi-project-fe/src/app/page/schedule/schedule-page.component.html
@@ -17,7 +17,9 @@
   (openCalendar)="openCalendar()"
   (closeCalendar)="closeCalendar()"
   (create)="onSave($event)"
-  (openTaskDetail)="openTaskDetail($event)"
-  (closeTaskDetail)="closeTaskDetail()"
-  (editTask)="onEdit($event)"
-  (deleteTask)="onDelete($event)"></app-schedule-layout>
+    (openTaskDetail)="openTaskDetail($event)"
+    (closeTaskDetail)="closeTaskDetail()"
+    (editTask)="onEdit($event)"
+    (deleteTask)="onDelete($event)"
+    (progressInput)="onProgressInput($event)"
+  ></app-schedule-layout>

--- a/asobi-fe/asobi-project-fe/src/app/page/schedule/schedule-page.component.ts
+++ b/asobi-fe/asobi-project-fe/src/app/page/schedule/schedule-page.component.ts
@@ -104,4 +104,8 @@ export class SchedulePageComponent implements OnInit {
     this.#scheduleService.remove(id);
     this.closeTaskDetail();
   }
+
+  onProgressInput(event: { task: Task; value: number }): void {
+    this.#scheduleService.addProgress(event.task.id, event.value);
+  }
 }

--- a/asobi-fe/asobi-project-fe/src/app/view/layouts/schedule-layout/schedule-layout.component.html
+++ b/asobi-fe/asobi-project-fe/src/app/view/layouts/schedule-layout/schedule-layout.component.html
@@ -21,6 +21,7 @@
       [memos]="memos"
       (memoChange)="memoChange.emit($event)"
       (taskClick)="openTaskDetail.emit($event)"
+      (progressInput)="progressInput.emit($event)"
     ></app-gantt-chart>
     @if (calendarVisible) {
       <app-calendar-modal

--- a/asobi-fe/asobi-project-fe/src/app/view/layouts/schedule-layout/schedule-layout.component.ts
+++ b/asobi-fe/asobi-project-fe/src/app/view/layouts/schedule-layout/schedule-layout.component.ts
@@ -57,6 +57,7 @@ export class ScheduleLayoutComponent {
   @Output() closeTaskDetail = new EventEmitter<void>();
   @Output() editTask = new EventEmitter<Task>();
   @Output() deleteTask = new EventEmitter<string>();
+  @Output() progressInput = new EventEmitter<{ task: Task; value: number }>();
 
   onCalendarConfirm(date: Date): void {
     this.ganttChart?.scrollToDate(date);

--- a/asobi-fe/asobi-project-fe/src/app/view/parts/gantt-chart/gantt-chart.component.html
+++ b/asobi-fe/asobi-project-fe/src/app/view/parts/gantt-chart/gantt-chart.component.html
@@ -135,17 +135,23 @@
       <tbody>
         @for (row of emptyRows; track $index; let i = $index) {
           @if (taskViews[i]; as view) {
-            <tr (click)="onRowClick(view)">
-              <td class="sticky-left col-type">{{ view.task.type }}</td>
-              <td class="sticky-left col-name">{{ view.task.name }}</td>
-              <td class="sticky-left col-assignee">{{ view.task.assignee }}</td>
-              <td class="sticky-left col-start">
+            <tr>
+              <td class="sticky-left col-type" (click)="onRowClick(view)">
+                {{ view.task.type }}
+              </td>
+              <td class="sticky-left col-name" (click)="onRowClick(view)">
+                {{ view.task.name }}
+              </td>
+              <td class="sticky-left col-assignee" (click)="onRowClick(view)">
+                {{ view.task.assignee }}
+              </td>
+              <td class="sticky-left col-start" (click)="onRowClick(view)">
                 {{ view.task.start | date: "yyyy-MM-dd" }}
               </td>
-              <td class="sticky-left col-end">
+              <td class="sticky-left col-end" (click)="onRowClick(view)">
                 {{ view.task.end | date: "yyyy-MM-dd" }}
               </td>
-              <td class="sticky-left col-progress">
+              <td class="sticky-left col-progress" (click)="onRowClick(view)">
                 {{ view.task.progress }}%
               </td>
 
@@ -155,6 +161,7 @@
                   (mousedown)="onCellMouseDown($event, i, j)"
                   (mouseenter)="onColumnMouseEnter(j)"
                   (mouseleave)="onColumnMouseLeave()"
+                  (click)="startProgressEdit(view.task, i, j)"
                   [class.column-hover]="hoveredColIdx === j"
                   [class.focused]="isFocusedCell(i, j)"
                   [class.progress]="isProgress(view, date)"
@@ -164,7 +171,18 @@
                   [class.planned-start]="isPlannedStart(view, date)"
                   [class.planned-end]="isPlannedEnd(view, date)"
                   [class.month-boundary]="isMonthStart(date) && j !== 0"
-                ></td>
+                >
+                  @if (isEditingCell(i, j)) {
+                    <input
+                      type="number"
+                      class="progress-input"
+                      [(ngModel)]="progressValue"
+                      (keyup.enter)="commitProgress()"
+                      (blur)="commitProgress()"
+                      autofocus
+                    />
+                  }
+                </td>
               }
             </tr>
           } @else {

--- a/asobi-fe/asobi-project-fe/src/app/view/parts/gantt-chart/gantt-chart.component.scss
+++ b/asobi-fe/asobi-project-fe/src/app/view/parts/gantt-chart/gantt-chart.component.scss
@@ -290,6 +290,15 @@ thead .sticky-left.h {
   position: relative;
 }
 
+.progress-input {
+  width: 100%;
+  height: 100%;
+  border: none;
+  padding: 0;
+  text-align: center;
+  background: transparent;
+}
+
 /* 各列の縦罫線（最終列を除く） */
 .date-col,
 .day {

--- a/asobi-fe/asobi-project-fe/src/app/view/parts/gantt-chart/gantt-chart.component.ts
+++ b/asobi-fe/asobi-project-fe/src/app/view/parts/gantt-chart/gantt-chart.component.ts
@@ -57,6 +57,7 @@ export class GanttChartComponent
   @Input({ required: true }) memos: Memo[] = [];
   @Output() memoChange = new EventEmitter<Memo>();
   @Output() taskClick = new EventEmitter<Task>();
+  @Output() progressInput = new EventEmitter<{ task: Task; value: number }>();
   @Output() rangeChange = new EventEmitter<{ start: Date; end: Date }>();
   @ViewChild('scrollHost') private scrollHost?: ElementRef<HTMLDivElement>;
   @ViewChild('hScrollbar') private hScrollbar?: ElementRef<HTMLDivElement>;
@@ -108,6 +109,8 @@ export class GanttChartComponent
   private focusedCellIdx?: { row: number; col: number };
   protected hoveredColIdx: number | null = null;
   protected editingMemoId: string | null = null;
+  protected editingCell: { row: number; col: number; task: Task } | null = null;
+  protected progressValue = '';
   private isScrolling = false;
   private resizeSub?: Subscription;
   private shouldScrollToToday = true;
@@ -341,6 +344,27 @@ export class GanttChartComponent
       y: cellRect.top - hostRect.top + host.scrollTop,
     };
     this.focusedCellIdx = { row: rowIdx, col: colIdx };
+  }
+
+  startProgressEdit(task: Task, rowIdx: number, colIdx: number): void {
+    this.editingCell = { row: rowIdx, col: colIdx, task };
+    this.progressValue = '';
+  }
+
+  isEditingCell(rowIdx: number, colIdx: number): boolean {
+    return (
+      this.editingCell?.row === rowIdx && this.editingCell?.col === colIdx
+    );
+  }
+
+  commitProgress(): void {
+    if (!this.editingCell) return;
+    const value = Number(this.progressValue);
+    if (!isNaN(value) && value > 0) {
+      this.progressInput.emit({ task: this.editingCell.task, value });
+    }
+    this.editingCell = null;
+    this.progressValue = '';
   }
 
   getFocusedCellPosition(): { x: number; y: number } | null {


### PR DESCRIPTION
## Summary
- allow progress editing by clicking date cells
- only open task detail modal when clicking sticky task columns
- add service support for progress increments

## Testing
- `CHROME_BIN=chromium-browser npm test` *(fails: Chrome requires snap installation)*

------
https://chatgpt.com/codex/tasks/task_e_689d556196dc83319c361adb3ad4f256