### PR TITLE
フロントエンドドキュメントの再構成とクラス別説明の追加

### DIFF
--- a/asobi-fe/document/classes/gantt-chart-component.md
+++ b/asobi-fe/document/classes/gantt-chart-component.md
@@ -1,0 +1,26 @@
+# GanttChartComponent
+
+タスクとメモをガントチャート形式で表示するコンポーネント。
+
+## 入出力
+- `@Input() tasks: Task[]` — 表示するタスク。
+- `@Input() memos: Memo[]` — 表示するメモ。
+- `@Output() memoChange` — メモ編集イベント。
+- `@Output() taskClick` — タスククリックイベント。
+- `@Output() progressInput` — 進捗入力イベント。
+- `@Output() rangeChange` — 表示期間変更イベント。
+
+## 主なフィールド
+- `dateRange: Date[]` — 表示期間の日付リスト。
+- `taskViews: TaskView[]` — 表示用に加工されたタスク。
+- `filters` — フィルタ状態。
+- `spanOffset` — 表示範囲のオフセット。
+
+## 主なメソッド
+- `moveSpan(direction)` — 表示期間を月単位で移動。
+- `onScrollbarMouseDown(event)` — 独自スクロールバーのドラッグ開始。
+- `updateRange()` — 表示期間を再計算。
+- `updateScrollbarThumb()` — スクロールバーの表示を更新。
+
+## 関連ファイル
+- `src/app/view/parts/gantt-chart/gantt-chart.component.ts`

--- a/asobi-fe/document/classes/memo-component.md
+++ b/asobi-fe/document/classes/memo-component.md
@@ -1,0 +1,22 @@
+# MemoComponent
+
+ガントチャート上に配置するメモを表示・編集するコンポーネント。
+
+## 入出力
+- `@Input() memo: Memo` — 表示するメモ。
+- `@Input() editing: boolean` — 編集モード。
+- `@Output() memoMouseDown` — ドラッグ開始イベント。
+- `@Output() memoMouseUp` — ドラッグ終了イベント。
+- `@Output() memoResizeMouseDown` — リサイズ開始イベント。
+- `@Output() memoBlur` — フォーカス喪失イベント。
+- `@Output() editToggle` — 編集モード切替イベント。
+
+## メソッド
+- `onMouseDown(event)` — ドラッグ開始イベントを発火。
+- `onMouseUp(event)` — ドラッグ終了イベントを発火。
+- `onResizeMouseDown(event)` — リサイズ開始イベントを発火。
+- `onBlur(event)` — 編集内容確定を通知。
+- `onEditButton(event)` — 編集モードを切り替え。
+
+## 関連ファイル
+- `src/app/view/parts/memo/memo.component.ts`

--- a/asobi-fe/document/classes/memo-service.md
+++ b/asobi-fe/document/classes/memo-service.md
@@ -1,0 +1,18 @@
+# MemoService
+
+メモの追加・更新・削除を行うサービス。`MemoServiceInterface`を実装する。
+
+## フィールド
+- `memos: Signal<Memo[]>` — 現在のメモ一覧。
+
+## メソッド
+- `add(memo: Memo)` — メモを追加。
+- `update(memo: Memo)` — メモを更新。
+- `remove(id: string)` — メモを削除。
+
+## 依存関係
+- `MemoState` — メモの状態管理。
+
+## 関連ファイル
+- `src/app/domain/service/interface/memo.service.ts`
+- `src/app/domain/service/impl/memo.service.impl.ts`

--- a/asobi-fe/document/classes/memo-state.md
+++ b/asobi-fe/document/classes/memo-state.md
@@ -1,0 +1,15 @@
+# MemoState
+
+メモ一覧をSignalで管理する状態クラス。
+
+## フィールド
+- `memos: Signal<Memo[]>` — 現在のメモ一覧。
+
+## メソッド
+- `add(memo: Memo)` — メモを追加。
+- `update(memo: Memo)` — メモを更新。
+- `remove(id: string)` — メモを削除。
+
+## 関連ファイル
+- `src/app/domain/state/interface/memo-state.ts`
+- `src/app/domain/state/local/memo.state.ts`

--- a/asobi-fe/document/classes/memo.md
+++ b/asobi-fe/document/classes/memo.md
@@ -1,0 +1,16 @@
+# Memo
+
+ガントチャート上に貼り付けるメモを表すインターフェース。
+
+## フィールド
+| フィールド | 型 | 説明 |
+|---|---|---|
+| id | string | 識別子 |
+| text | string | 本文 |
+| x | number | X座標 |
+| y | number | Y座標 |
+| width | number | 幅 |
+| height | number | 高さ |
+
+## 関連ファイル
+- `src/app/domain/model/memo.ts`

--- a/asobi-fe/document/classes/schedule-page-component.md
+++ b/asobi-fe/document/classes/schedule-page-component.md
@@ -1,0 +1,31 @@
+# SchedulePageComponent
+
+アプリのメインページコンポーネント。
+
+## フィールド
+- `tasks` — タスク一覧のSignal。
+- `memos` — メモ一覧のSignal。
+- `isFormVisible` — タスクフォーム表示フラグ。
+- `isCalendarVisible` — カレンダーモーダル表示フラグ。
+- `isMemoVisible` — メモモーダル表示フラグ。
+- `isTaskDetailVisible` — タスク詳細モーダル表示フラグ。
+- `selectedTask` — 選択中のタスク。
+- `editingTask` — 編集対象のタスク。
+- `dateTime` — 現在日時のSignal。
+
+## メソッド
+- `ngOnInit()` — 初期化処理。タスク読み込みと時計開始を実行。
+- `openForm()/closeForm()` — タスクフォームを開閉。
+- `openCalendar()/closeCalendar()` — カレンダーモーダルを開閉。
+- `openMemo()/closeMemo()` — メモモーダルを開閉。
+- `onSave(task)` — タスクを保存しフォームを閉じる。
+- `onMemoCreate(event)` — メモを作成。
+- `onMemoChange(memo)` — メモを更新。
+- `openTaskDetail(task)` — タスク詳細を表示。
+- `closeTaskDetail()` — タスク詳細を閉じる。
+- `onEdit(task)` — タスクを編集モードで開く。
+- `onDelete(id)` — タスクを削除。
+- `onProgressInput(event)` — 進捗値を更新。
+
+## 関連ファイル
+- `src/app/page/schedule/schedule-page.component.ts`

--- a/asobi-fe/document/classes/schedule-service.md
+++ b/asobi-fe/document/classes/schedule-service.md
@@ -1,0 +1,21 @@
+# ScheduleService
+
+タスクの読み込みや変更を行うサービス。`ScheduleServiceInterface`を実装する。
+
+## フィールド
+- `tasks: Signal<Task[]>` — 現在のタスク一覧。
+
+## メソッド
+- `load()` — リポジトリからタスクを取得し状態に追加。
+- `add(task: Task)` — タスクを追加。
+- `update(task: Task)` — タスクを更新。
+- `remove(id: string)` — タスクを削除。
+- `addProgress(id: string, value: number)` — 指定タスクの進捗を加算。
+
+## 依存関係
+- `ScheduleRepository` — APIとの通信。
+- `ScheduleState` — タスクの状態管理。
+
+## 関連ファイル
+- `src/app/domain/service/interface/schedule.service.ts`
+- `src/app/domain/service/impl/schedule.service.impl.ts`

--- a/asobi-fe/document/classes/schedule-state.md
+++ b/asobi-fe/document/classes/schedule-state.md
@@ -1,0 +1,15 @@
+# ScheduleState
+
+タスク一覧をSignalで管理する状態クラス。
+
+## フィールド
+- `tasks: Signal<Task[]>` — 現在のタスク一覧。
+
+## メソッド
+- `add(task: Task)` — タスクを追加。
+- `update(task: Task)` — タスクを更新。
+- `remove(id: string)` — タスクを削除。
+
+## 関連ファイル
+- `src/app/domain/state/interface/schedule-state.ts`
+- `src/app/domain/state/local/schedule.state.ts`

--- a/asobi-fe/document/classes/task-form-component.md
+++ b/asobi-fe/document/classes/task-form-component.md
@@ -1,0 +1,18 @@
+# TaskFormComponent
+
+タスクを入力するフォームコンポーネント。
+
+## フィールド
+- `task` — 入力値を保持する内部状態。
+
+## 入出力
+- `@Input() initialTask` — 初期表示するタスク。
+- `@Output() save` — 入力されたタスクを通知。
+
+## メソッド
+- `submit()` — 入力値から`Task`を生成し`save`イベントを発火。
+- `reset()` — 内部状態を初期化。
+- `formatDate(date)` — 日付を`YYYY-MM-DD`形式に変換。
+
+## 関連ファイル
+- `src/app/view/parts/task-form/task-form.component.ts`

--- a/asobi-fe/document/classes/task.md
+++ b/asobi-fe/document/classes/task.md
@@ -1,0 +1,18 @@
+# Task
+
+タスクを表すインターフェース。
+
+## フィールド
+| フィールド | 型 | 説明 |
+|---|---|---|
+| id | string | 識別子 |
+| type | string | 分類（フェーズなど） |
+| name | string | タスク名 |
+| detail | string | 詳細説明 |
+| assignee | string | 担当者 |
+| start | Date | 開始日 |
+| end | Date | 終了日 |
+| progress | number | 進捗率(0-100) |
+
+## 関連ファイル
+- `src/app/domain/model/task.ts`

--- a/asobi-fe/document/frontend-overview.md
+++ b/asobi-fe/document/frontend-overview.md
@@ -1,16 +1,20 @@
 # フロントエンドアプリケーション概要
 
-## 画面一覧
-- **スケジュールページ**: ヘッダー、ガントチャート、タスク追加フォーム、メモ追加モーダル、カレンダーモーダル、タスク詳細モーダルで構成され、タスクの管理とメモ貼り付けを行う。
+## 1. アプリの機能説明
+- タスクの追加・更新・削除、進捗管理。
+- ガントチャートでのタスク表示とメモ配置。
+- カレンダーから任意の日付へスクロール。
+- タスク詳細の閲覧・編集、メモの移動・リサイズ。
 
-## 主な機能
-- 初期表示時にタスク一覧を読み込み、現在時刻を表示。
-- タスクの追加・更新・削除、進捗入力。
-- ガントチャート上でメモの作成・移動・リサイズ。
-- カレンダーから特定日へスクロール。
-- タスク詳細の閲覧と編集。
+## 2. 画面機能説明
+### スケジュールページ
+- ヘッダー、フッター、ガントチャートで構成。
+- タスクフォームでタスクの登録・編集。
+- メモモーダルでメモの作成・編集。
+- カレンダーモーダルから指定日へジャンプ。
+- タスク詳細モーダルで内容確認と削除。
 
-## フォルダ構成
+## 3. ディレクトリ構造
 ```
 src/app
 ├── domain
@@ -22,54 +26,20 @@ src/app
 └── view             # 表示専用コンポーネント
 ```
 
-## フォルダ依存関係
-- **page** は **service** を介して **state** と通信し、状態を **view** に渡す。
-- **service** は **infrastructure**（API/Repository）を利用して外部データを取得・更新する。
-- **view** は状態を受け取って描画し、ユーザー操作イベントを発火する。
+## 4. クラスの依存関係
+- **SchedulePageComponent** は **ScheduleService** と **MemoService** を利用し、状態を取得して各ビューに渡す。
+- **ScheduleService** は **ScheduleRepository** を介してAPIと通信し、結果を **ScheduleState** に反映する。
+- **MemoService** は **MemoState** を操作してメモを管理する。
+- **view** 配下のコンポーネントは受け取った状態を表示し、ユーザー操作をイベントとして発火する。
 
-## 主要クラスとインターフェース
-### Taskインターフェース
-| フィールド | 説明 |
-|-----------|------|
-| id | 識別子 |
-| type | 分類（フェーズ） |
-| name | タスク名 |
-| detail | 詳細説明 |
-| assignee | 担当者 |
-| start/end | 期間 |
-| progress | 進捗率(0-100) |
-
-### Memoインターフェース
-| フィールド | 説明 |
-|-----------|------|
-| id | 識別子 |
-| text | 本文 |
-| x/y | 配置位置 |
-| width/height | サイズ |
-
-### ScheduleServiceInterface
-- `tasks`: 現在のタスク一覧をSignalで公開。
-- `load()`: タスクを読み込み状態へ反映。
-- `add(task)`, `update(task)`, `remove(id)`: タスクのCRUD。
-- `addProgress(id, value)`: 進捗加算。
-
-### ScheduleService実装
-- `ScheduleRepository`と`ScheduleState`を利用。
-- `load()`でAPIからタスクを取得し`ScheduleState`へ追加。
-- 各CRUD操作時にリポジトリとステートを同期。
-
-### ScheduleState
-- `tasks`: `WritableSignal<Task[]>`で保持し、`add/update/remove`で変更。
-
-### SchedulePageComponent
-- サービスを注入し、`tasks`, `memos`, `dateTime`などを取得。
-- `openForm()/closeForm()`でタスクフォームを制御。
-- `openMemo()/closeMemo()`でメモモーダルを制御。
-- `onSave()`でタスク保存、`onDelete()`で削除。
-- `onMemoCreate()`でメモ生成、`onProgressInput()`で進捗更新。
-
-## 関数・フィールド概要
-- **タスクフォーム(TaskFormComponent)**: 入力値を`Task`に整形し`save`イベントを発火。
-- **ガントチャート(GanttChartComponent)**: タスク表示、フィルタ、メモ編集、スクロールレンジ管理。
-- **メモコンポーネント(MemoComponent)**: メモのドラッグ・リサイズ・編集操作をイベントとして提供。
-
+## 5. クラス概要
+- [Task](classes/task.md)
+- [Memo](classes/memo.md)
+- [ScheduleService](classes/schedule-service.md)
+- [ScheduleState](classes/schedule-state.md)
+- [MemoService](classes/memo-service.md)
+- [MemoState](classes/memo-state.md)
+- [SchedulePageComponent](classes/schedule-page-component.md)
+- [TaskFormComponent](classes/task-form-component.md)
+- [GanttChartComponent](classes/gantt-chart-component.md)
+- [MemoComponent](classes/memo-component.md)


### PR DESCRIPTION
## 概要
- フロントエンド概要ドキュメントを章立てし直し、機能説明や依存関係を整理
- クラスごとの詳細ドキュメントを新設し、リンクを追加

## テスト
- `npm test` (Chrome が存在せず失敗)

------
https://chatgpt.com/codex/tasks/task_e_689dd9226da8833182a6da881c8d9a3e