### PR TITLE
ログイン画面の追加とルーティングの整理

### DIFF
--- a/asobi-fe/asobi-project-fe/src/app/app.routes.ts
+++ b/asobi-fe/asobi-project-fe/src/app/app.routes.ts
@@ -1,6 +1,10 @@
 import { Routes } from '@angular/router';
+import { HomeComponent } from './page/home/home';
+import { LoginPageComponent } from './page/login/login-page.component';
 import { SchedulePageComponent } from './page/schedule/schedule-page.component';
 
 export const routes: Routes = [
-  { path: '', component: SchedulePageComponent }
+  { path: '', component: HomeComponent },
+  { path: 'login', component: LoginPageComponent },
+  { path: 'schedule', component: SchedulePageComponent }
 ];

--- a/asobi-fe/asobi-project-fe/src/app/page/home/home.spec.ts
+++ b/asobi-fe/asobi-project-fe/src/app/page/home/home.spec.ts
@@ -1,18 +1,18 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
-import { Home } from './home';
-
-describe('Home', () => {
-  let component: Home;
-  let fixture: ComponentFixture<Home>;
+import { HomeComponent } from './home';
+ 
+describe('HomeComponent', () => {
+  let component: HomeComponent;
+  let fixture: ComponentFixture<HomeComponent>;
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [Home]
+      imports: [HomeComponent]
     })
     .compileComponents();
 
-    fixture = TestBed.createComponent(Home);
+    fixture = TestBed.createComponent(HomeComponent);
     component = fixture.componentInstance;
     fixture.detectChanges();
   });

--- a/asobi-fe/asobi-project-fe/src/app/page/home/home.ts
+++ b/asobi-fe/asobi-project-fe/src/app/page/home/home.ts
@@ -3,8 +3,8 @@ import { Router } from '@angular/router';
 
 @Component({
   selector: 'app-home',
-  templateUrl: './home.component.html',
-  styleUrls: ['./home.component.scss']
+  templateUrl: './home.html',
+  styleUrl: './home.scss'
 })
 export class HomeComponent {
   constructor(private router: Router) {}

--- a/asobi-fe/asobi-project-fe/src/app/page/login/login-page.component.html
+++ b/asobi-fe/asobi-project-fe/src/app/page/login/login-page.component.html
@@ -1,0 +1,1 @@
+<app-login-form (login)="onLogin($event)"></app-login-form>

--- a/asobi-fe/asobi-project-fe/src/app/page/login/login-page.component.scss
+++ b/asobi-fe/asobi-project-fe/src/app/page/login/login-page.component.scss
@@ -1,0 +1,4 @@
+:host {
+  display: block;
+  padding: 40px 0;
+}

--- a/asobi-fe/asobi-project-fe/src/app/page/login/login-page.component.ts
+++ b/asobi-fe/asobi-project-fe/src/app/page/login/login-page.component.ts
@@ -1,0 +1,18 @@
+import { Component } from '@angular/core';
+import { Router } from '@angular/router';
+import { LoginFormComponent } from '../../view/parts/login-form/login-form.component';
+
+@Component({
+  selector: 'app-login-page',
+  standalone: true,
+  imports: [LoginFormComponent],
+  templateUrl: './login-page.component.html',
+  styleUrl: './login-page.component.scss'
+})
+export class LoginPageComponent {
+  constructor(private router: Router) {}
+
+  onLogin(_: { identifier: string; password: string }): void {
+    this.router.navigate(['/schedule']);
+  }
+}

--- a/asobi-fe/asobi-project-fe/src/app/view/parts/login-form/login-form.component.html
+++ b/asobi-fe/asobi-project-fe/src/app/view/parts/login-form/login-form.component.html
@@ -1,0 +1,11 @@
+<form (ngSubmit)="onSubmit()">
+  <label>
+    メールアドレスまたは電話番号
+    <input type="text" name="identifier" [(ngModel)]="identifier" />
+  </label>
+  <label>
+    パスワード
+    <input type="password" name="password" [(ngModel)]="password" />
+  </label>
+  <button type="submit">ログイン</button>
+</form>

--- a/asobi-fe/asobi-project-fe/src/app/view/parts/login-form/login-form.component.scss
+++ b/asobi-fe/asobi-project-fe/src/app/view/parts/login-form/login-form.component.scss
@@ -1,0 +1,17 @@
+form {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  width: 300px;
+  margin: 0 auto;
+}
+
+label {
+  display: flex;
+  flex-direction: column;
+  font-weight: 600;
+}
+
+button {
+  margin-top: 16px;
+}

--- a/asobi-fe/asobi-project-fe/src/app/view/parts/login-form/login-form.component.ts
+++ b/asobi-fe/asobi-project-fe/src/app/view/parts/login-form/login-form.component.ts
@@ -1,0 +1,21 @@
+import { ChangeDetectionStrategy, Component, EventEmitter, Output } from '@angular/core';
+import { FormsModule } from '@angular/forms';
+
+@Component({
+  selector: 'app-login-form',
+  standalone: true,
+  imports: [FormsModule],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  templateUrl: './login-form.component.html',
+  styleUrl: './login-form.component.scss'
+})
+export class LoginFormComponent {
+  identifier = '';
+  password = '';
+
+  @Output() login = new EventEmitter<{ identifier: string; password: string }>();
+
+  onSubmit(): void {
+    this.login.emit({ identifier: this.identifier, password: this.password });
+  }
+}


### PR DESCRIPTION
## 概要
- ログインフォームを追加
- ログインページを作成し認証後にスケジュールページへ遷移
- HomeComponent/ルーティングを修正

## テスト
- `npm test -- --watch=false` : Chrome がないため失敗

------
https://chatgpt.com/codex/tasks/task_e_689ecf91c75c8331b9435edea832d0b1