### PR TITLE
feat: ログイン画面のデザインを改善

### DIFF
--- a/asobi-fe/asobi-project-fe/src/app/page/login/login-page.component.scss
+++ b/asobi-fe/asobi-project-fe/src/app/page/login/login-page.component.scss
@@ -1,4 +1,8 @@
 :host {
-  display: block;
-  padding: 40px 0;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  min-height: 100vh;
+  padding: 16px;
+  background: linear-gradient(135deg, #74ebd5 0%, #9face6 100%);
 }

--- a/asobi-fe/asobi-project-fe/src/app/view/parts/login-form/login-form.component.html
+++ b/asobi-fe/asobi-project-fe/src/app/view/parts/login-form/login-form.component.html
@@ -1,11 +1,16 @@
 <form (ngSubmit)="onSubmit()">
-  <label>
-    メールアドレスまたは電話番号
-    <input type="text" name="identifier" [(ngModel)]="identifier" />
-  </label>
-  <label>
-    パスワード
-    <input type="password" name="password" [(ngModel)]="password" />
-  </label>
+  <h2>ログイン</h2>
+  <input
+    type="text"
+    name="identifier"
+    [(ngModel)]="identifier"
+    placeholder="メールアドレスまたは電話番号"
+  />
+  <input
+    type="password"
+    name="password"
+    [(ngModel)]="password"
+    placeholder="パスワード"
+  />
   <button type="submit">ログイン</button>
 </form>

--- a/asobi-fe/asobi-project-fe/src/app/view/parts/login-form/login-form.component.scss
+++ b/asobi-fe/asobi-project-fe/src/app/view/parts/login-form/login-form.component.scss
@@ -1,17 +1,53 @@
+:host {
+  display: block;
+  width: 100%;
+}
+
 form {
   display: flex;
   flex-direction: column;
-  gap: 8px;
-  width: 300px;
+  gap: 16px;
+  width: 100%;
+  max-width: 360px;
+  padding: 32px 24px;
   margin: 0 auto;
+  background: rgba(255, 255, 255, 0.85);
+  backdrop-filter: blur(6px);
+  border-radius: 12px;
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.15);
 }
 
-label {
-  display: flex;
-  flex-direction: column;
-  font-weight: 600;
+h2 {
+  margin: 0;
+  text-align: center;
+}
+
+input {
+  padding: 12px;
+  border: 1px solid #d1d5db;
+  border-radius: 8px;
+  font-size: 1rem;
+  transition: border-color 0.2s, box-shadow 0.2s;
+
+  &:focus {
+    outline: none;
+    border-color: #4f46e5;
+    box-shadow: 0 0 0 3px rgba(79, 70, 229, 0.15);
+  }
 }
 
 button {
-  margin-top: 16px;
+  margin-top: 8px;
+  padding: 12px;
+  border: none;
+  border-radius: 8px;
+  background-color: #4f46e5;
+  color: #fff;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background-color 0.2s;
+
+  &:hover {
+    background-color: #4338ca;
+  }
 }


### PR DESCRIPTION
## 概要
- ログイン画面をモダンなデザインに刷新
- 入力フォームをカード風レイアウトに調整

## テスト
- `npm test` (Chrome がないため失敗)

------
https://chatgpt.com/codex/tasks/task_e_689ed24f33e08331b4b17e020236c274