### PR TITLE
feat: navigate to login on logout

### DIFF
--- a/asobi-fe/asobi-project-fe/src/app/page/schedule/schedule-page.component.html
+++ b/asobi-fe/asobi-project-fe/src/app/page/schedule/schedule-page.component.html
@@ -17,6 +17,7 @@
   (openCalendar)="openCalendar()"
   (closeCalendar)="closeCalendar()"
   (create)="onSave($event)"
+  (logout)="onLogout()"
     (openTaskDetail)="openTaskDetail($event)"
     (closeTaskDetail)="closeTaskDetail()"
     (editTask)="onEdit($event)"

--- a/asobi-fe/asobi-project-fe/src/app/page/schedule/schedule-page.component.ts
+++ b/asobi-fe/asobi-project-fe/src/app/page/schedule/schedule-page.component.ts
@@ -1,4 +1,5 @@
 import { ChangeDetectionStrategy, Component, OnInit, inject, signal } from '@angular/core';
+import { Router } from '@angular/router';
 import { ScheduleLayoutComponent } from '../../view/layouts/schedule-layout/schedule-layout.component';
 import { ScheduleService } from '../../domain/service/impl/schedule.service.impl';
 import { Task } from '../../domain/model/task';
@@ -17,6 +18,7 @@ export class SchedulePageComponent implements OnInit {
   #scheduleService = inject(ScheduleService);
   #clockService = inject(ClockService);
   #memoService = inject(MemoService);
+  #router = inject(Router);
   protected tasks = this.#scheduleService.tasks;
   protected memos = this.#memoService.memos;
   protected isFormVisible = signal(false);
@@ -107,5 +109,9 @@ export class SchedulePageComponent implements OnInit {
 
   onProgressInput(event: { task: Task; value: number }): void {
     this.#scheduleService.addProgress(event.task.id, event.value);
+  }
+
+  onLogout(): void {
+    this.#router.navigate(['/login']);
   }
 }

--- a/asobi-fe/asobi-project-fe/src/app/view/layouts/schedule-layout/schedule-layout.component.html
+++ b/asobi-fe/asobi-project-fe/src/app/view/layouts/schedule-layout/schedule-layout.component.html
@@ -1,5 +1,5 @@
 <div class="layout">
-  <app-header></app-header>
+  <app-header (logout)="logout.emit()"></app-header>
   <div class="content">
     <div class="toolbar">
       <button class="add-task" (click)="openForm.emit()">

--- a/asobi-fe/asobi-project-fe/src/app/view/layouts/schedule-layout/schedule-layout.component.ts
+++ b/asobi-fe/asobi-project-fe/src/app/view/layouts/schedule-layout/schedule-layout.component.ts
@@ -58,6 +58,7 @@ export class ScheduleLayoutComponent {
   @Output() editTask = new EventEmitter<Task>();
   @Output() deleteTask = new EventEmitter<string>();
   @Output() progressInput = new EventEmitter<{ task: Task; value: number }>();
+  @Output() logout = new EventEmitter<void>();
 
   onCalendarConfirm(date: Date): void {
     this.ganttChart?.scrollToDate(date);


### PR DESCRIPTION
## Summary
- Schedule layout propagates header logout event
- Schedule page handles logout event and routes to login screen

## Testing
- `CHROME_BIN=chromium-browser npm test -- --watch=false` *(fails: Command '/usr/bin/chromium-browser' requires the chromium snap to be installed)*

------
https://chatgpt.com/codex/tasks/task_e_689ed2f6d9288331ae75dddee1ad22ed