### PR TITLE
feat: 認証バックエンドの実装

### DIFF
--- a/asobi-be/asobi-project-be-app/src/main/java/com/asobi/controller/AsobiProject.java
+++ b/asobi-be/asobi-project-be-app/src/main/java/com/asobi/controller/AsobiProject.java
@@ -1,5 +1,0 @@
-package com.asobi.controller;
-
-public class AsobiProject {
-
-}

--- a/asobi-be/asobi-project-be-app/src/main/java/com/asobi/controller/LoginController.java
+++ b/asobi-be/asobi-project-be-app/src/main/java/com/asobi/controller/LoginController.java
@@ -1,0 +1,55 @@
+package com.asobi.controller;
+
+import com.asobi.domain.model.Account;
+import com.asobi.domain.service.IF.LoginServiceIF;
+import java.util.Optional;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * ログイン用のRESTコントローラ。
+ */
+@RestController
+@RequestMapping("/api")
+public class LoginController {
+
+    private final LoginServiceIF loginService;
+
+    public LoginController(LoginServiceIF loginService) {
+        this.loginService = loginService;
+    }
+
+    @PostMapping("/login")
+    public ResponseEntity<Account> login(@RequestBody LoginRequest request) {
+        Optional<Account> account = loginService.login(request.getUsername(), request.getPassword());
+        return account.map(ResponseEntity::ok)
+                .orElseGet(() -> ResponseEntity.status(401).build());
+    }
+
+    /**
+     * ログインリクエスト。
+     */
+    public static class LoginRequest {
+        private String username;
+        private String password;
+
+        public String getUsername() {
+            return username;
+        }
+
+        public void setUsername(String username) {
+            this.username = username;
+        }
+
+        public String getPassword() {
+            return password;
+        }
+
+        public void setPassword(String password) {
+            this.password = password;
+        }
+    }
+}

--- a/asobi-be/asobi-project-be-app/src/main/java/com/asobi/domain/model/Account.java
+++ b/asobi-be/asobi-project-be-app/src/main/java/com/asobi/domain/model/Account.java
@@ -1,0 +1,22 @@
+package com.asobi.domain.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * ドメインモデル: アカウント情報を表す。
+ */
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class Account {
+    /** ユーザーID */
+    private String username;
+
+    /** パスワード */
+    private String password;
+
+    /** 表示名 */
+    private String displayName;
+}

--- a/asobi-be/asobi-project-be-app/src/main/java/com/asobi/domain/model/account.java
+++ b/asobi-be/asobi-project-be-app/src/main/java/com/asobi/domain/model/account.java
@@ -1,5 +1,0 @@
-package com.asobi.domain.model;
-
-public class account {
-
-}

--- a/asobi-be/asobi-project-be-app/src/main/java/com/asobi/domain/repository/IF/LoginRepositoryIF.java
+++ b/asobi-be/asobi-project-be-app/src/main/java/com/asobi/domain/repository/IF/LoginRepositoryIF.java
@@ -1,5 +1,19 @@
 package com.asobi.domain.repository.IF;
 
-public class LoginRepositoryIF {
+import com.asobi.domain.model.Account;
+import java.util.Optional;
 
+/**
+ * ログイン処理用リポジトリのインターフェース。
+ */
+public interface LoginRepositoryIF {
+
+    /**
+     * ユーザーIDとパスワードでアカウントを取得する。
+     *
+     * @param username ユーザーID
+     * @param password パスワード
+     * @return アカウント。存在しない場合は空。
+     */
+    Optional<Account> findByCredentials(String username, String password);
 }

--- a/asobi-be/asobi-project-be-app/src/main/java/com/asobi/domain/service/IF/LoginServiceIF.java
+++ b/asobi-be/asobi-project-be-app/src/main/java/com/asobi/domain/service/IF/LoginServiceIF.java
@@ -1,5 +1,19 @@
 package com.asobi.domain.service.IF;
 
+import com.asobi.domain.model.Account;
+import java.util.Optional;
+
+/**
+ * ログイン処理のサービスインターフェース。
+ */
 public interface LoginServiceIF {
 
+    /**
+     * ログインを実行する。
+     *
+     * @param username ユーザーID
+     * @param password パスワード
+     * @return アカウント。認証失敗時は空。
+     */
+    Optional<Account> login(String username, String password);
 }

--- a/asobi-be/asobi-project-be-app/src/main/java/com/asobi/domain/service/impl/LoginServiceImpl.java
+++ b/asobi-be/asobi-project-be-app/src/main/java/com/asobi/domain/service/impl/LoginServiceImpl.java
@@ -1,7 +1,25 @@
 package com.asobi.domain.service.impl;
 
+import com.asobi.domain.model.Account;
+import com.asobi.domain.repository.IF.LoginRepositoryIF;
 import com.asobi.domain.service.IF.LoginServiceIF;
+import java.util.Optional;
+import org.springframework.stereotype.Service;
 
+/**
+ * ログインサービスの実装。
+ */
+@Service
 public class LoginServiceImpl implements LoginServiceIF {
 
+    private final LoginRepositoryIF loginRepository;
+
+    public LoginServiceImpl(LoginRepositoryIF loginRepository) {
+        this.loginRepository = loginRepository;
+    }
+
+    @Override
+    public Optional<Account> login(String username, String password) {
+        return loginRepository.findByCredentials(username, password);
+    }
 }

--- a/asobi-be/asobi-project-be-app/src/main/java/com/asobi/infrastructure/db/entity/AccountInfo.java
+++ b/asobi-be/asobi-project-be-app/src/main/java/com/asobi/infrastructure/db/entity/AccountInfo.java
@@ -1,5 +1,24 @@
 package com.asobi.infrastructure.db.entity;
 
-public class AccountInfo {
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.Data;
 
+/**
+ * DBエンティティ: アカウント情報。
+ */
+@Entity
+@Table(name = "account")
+@Data
+public class AccountInfo {
+    /** ユーザーID */
+    @Id
+    private String username;
+
+    /** パスワード */
+    private String password;
+
+    /** 表示名 */
+    private String displayName;
 }

--- a/asobi-be/asobi-project-be-app/src/main/java/com/asobi/infrastructure/db/stored/LoginStoredProc.java
+++ b/asobi-be/asobi-project-be-app/src/main/java/com/asobi/infrastructure/db/stored/LoginStoredProc.java
@@ -1,5 +1,42 @@
 package com.asobi.infrastructure.db.stored;
 
+import com.asobi.infrastructure.db.entity.AccountInfo;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.NoResultException;
+import jakarta.persistence.ParameterMode;
+import jakarta.persistence.StoredProcedureQuery;
+import org.springframework.stereotype.Repository;
+
+/**
+ * ログイン用ストアドプロシージャを呼び出すクラス。
+ */
+@Repository
 public class LoginStoredProc {
 
+    private final EntityManager entityManager;
+
+    public LoginStoredProc(EntityManager entityManager) {
+        this.entityManager = entityManager;
+    }
+
+    /**
+     * ユーザーIDとパスワードでストアドを実行し、該当するアカウント情報を取得する。
+     *
+     * @param username ユーザーID
+     * @param password パスワード
+     * @return アカウント情報。存在しない場合はnull。
+     */
+    public AccountInfo call(String username, String password) {
+        StoredProcedureQuery query = entityManager
+                .createStoredProcedureQuery("login_proc", AccountInfo.class);
+        query.registerStoredProcedureParameter("p_username", String.class, ParameterMode.IN);
+        query.registerStoredProcedureParameter("p_password", String.class, ParameterMode.IN);
+        query.setParameter("p_username", username);
+        query.setParameter("p_password", password);
+        try {
+            return (AccountInfo) query.getSingleResult();
+        } catch (NoResultException e) {
+            return null;
+        }
+    }
 }

--- a/asobi-be/asobi-project-be-app/src/main/java/com/asobi/infrastructure/repository/impl/LoginRepositoryImpl.java
+++ b/asobi-be/asobi-project-be-app/src/main/java/com/asobi/infrastructure/repository/impl/LoginRepositoryImpl.java
@@ -1,7 +1,31 @@
 package com.asobi.infrastructure.repository.impl;
 
-import com.asobi.domain.service.IF.LoginServiceIF;
+import com.asobi.domain.model.Account;
+import com.asobi.domain.repository.IF.LoginRepositoryIF;
+import com.asobi.infrastructure.db.entity.AccountInfo;
+import com.asobi.infrastructure.db.stored.LoginStoredProc;
+import java.util.Optional;
+import org.springframework.stereotype.Repository;
 
-public class LoginRepositoryImpl implements LoginServiceIF {
+/**
+ * ログインリポジトリの実装。
+ */
+@Repository
+public class LoginRepositoryImpl implements LoginRepositoryIF {
 
+    private final LoginStoredProc storedProc;
+
+    public LoginRepositoryImpl(LoginStoredProc storedProc) {
+        this.storedProc = storedProc;
+    }
+
+    @Override
+    public Optional<Account> findByCredentials(String username, String password) {
+        AccountInfo info = storedProc.call(username, password);
+        if (info == null) {
+            return Optional.empty();
+        }
+        Account account = new Account(info.getUsername(), info.getPassword(), info.getDisplayName());
+        return Optional.of(account);
+    }
 }


### PR DESCRIPTION
## 概要
- ログインAPIの実装
- サービス/リポジトリ/ストアド呼び出しの実装

## テスト
- `mvn -q -e -DskipTests package` (失敗: Network is unreachable)

------
https://chatgpt.com/codex/tasks/task_e_68c6a6775bdc833195c8a0c6fcb63e8c