### PR TITLE
feat: 招待管理APIの実装

### DIFF
--- a/asobi-be/asobi-auth-app/app/deps.py
+++ b/asobi-be/asobi-auth-app/app/deps.py
@@ -1,6 +1,7 @@
 # app/deps.py
 import firebase_admin
 from firebase_admin import credentials, auth, app_check
+from google.cloud import firestore, logging as cloud_logging
 
 # ★ ローカル開発では環境変数を設定しておく：
 # export GOOGLE_APPLICATION_CREDENTIALS="/absolute/path/to/service-account.json"
@@ -11,6 +12,12 @@ if not firebase_admin._apps:
     cred = credentials.ApplicationDefault()
     firebase_admin.initialize_app(cred)
 
+# Firestore クライアント（招待台帳用）
+_firestore_client: firestore.Client | None = None
+
+# Cloud Logging クライアント
+_logging_client: cloud_logging.Client | None = None
+
 def verify_id_token(id_token: str):
     """Firebase IDトークンを検証し、デコード結果(dict)を返す。失敗時は例外。"""
     return auth.verify_id_token(id_token)
@@ -18,3 +25,24 @@ def verify_id_token(id_token: str):
 def verify_app_check_token(token: str):
     """App Checkトークンを検証。失敗時は例外。"""
     return app_check.verify_token(token)
+
+
+def get_db() -> firestore.Client:
+    """Firestore クライアントを返す（シングルトン）。"""
+    global _firestore_client
+    if _firestore_client is None:
+        _firestore_client = firestore.Client()
+    return _firestore_client
+
+
+def get_logger():
+    """Cloud Logging ロガーを返す（シングルトン）。"""
+    global _logging_client
+    if _logging_client is None:
+        _logging_client = cloud_logging.Client()
+    return _logging_client.logger("asobi-auth-app")
+
+
+def invites_collection():
+    """招待台帳のコレクション参照を返す。"""
+    return get_db().collection("invites")

--- a/asobi-be/asobi-auth-app/app/invite.py
+++ b/asobi-be/asobi-auth-app/app/invite.py
@@ -1,0 +1,84 @@
+# app/invite.py
+from datetime import datetime, timedelta
+import os
+from fastapi import APIRouter, Depends, Header, HTTPException, status
+from pydantic import BaseModel, EmailStr, Field
+import httpx
+
+from app.deps import invites_collection, get_logger
+
+router = APIRouter(prefix="/admin", tags=["admin"])
+
+ADMIN_API_TOKEN = os.getenv("ADMIN_API_TOKEN", "changeme")
+
+
+class InviteRequest(BaseModel):
+    email: EmailStr
+    expires_in_days: int = Field(default=7, gt=0)
+    note: str | None = None
+
+
+class InviteResponse(BaseModel):
+    email: EmailStr
+    expires_at: datetime
+    status: str
+    note: str | None = None
+
+
+def require_admin(x_admin_token: str = Header(default=None)):
+    if x_admin_token != ADMIN_API_TOKEN:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="unauthorized")
+    return True
+
+
+async def send_invite_email(email: str, expires_at: datetime, note: str | None = None):
+    endpoint = os.getenv("MAILER_ENDPOINT")
+    message = {
+        "to": email,
+        "subject": "Invite to Asobi",
+        "body": f"You are invited. Expires at {expires_at.isoformat()}",
+    }
+    if not endpoint:
+        # 環境変数が無ければログ出力のみ
+        logger = get_logger()
+        logger.log_text(f"[MailerStub] {message}")
+        return
+    try:
+        async with httpx.AsyncClient() as client:
+            await client.post(endpoint, json=message, timeout=10)
+    except Exception as exc:  # 通信失敗時も例外は投げずログに記録
+        logger = get_logger()
+        logger.log_text(f"failed to call mailer: {exc}", severity="ERROR")
+
+
+@router.post("/invites", response_model=InviteResponse)
+async def create_invite(payload: InviteRequest, _=Depends(require_admin)):
+    col = invites_collection()
+    now = datetime.utcnow()
+    expires_at = now + timedelta(days=payload.expires_in_days)
+    doc = {
+        "email": payload.email,
+        "status": "pending",
+        "note": payload.note,
+        "created_at": now,
+        "expires_at": expires_at,
+    }
+    col.document(payload.email).set(doc)
+    await send_invite_email(payload.email, expires_at, payload.note)
+    logger = get_logger()
+    logger.log_text(f"invite created for {payload.email}")
+    return InviteResponse(email=payload.email, expires_at=expires_at, status="pending", note=payload.note)
+
+
+@router.get("/invites/{email}", response_model=InviteResponse)
+async def get_invite(email: str, _=Depends(require_admin)):
+    doc = invites_collection().document(email).get()
+    if not doc.exists:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="not found")
+    data = doc.to_dict()
+    return InviteResponse(
+        email=email,
+        expires_at=data.get("expires_at"),
+        status=data.get("status", "unknown"),
+        note=data.get("note"),
+    )

--- a/asobi-be/asobi-auth-app/app/main.py
+++ b/asobi-be/asobi-auth-app/app/main.py
@@ -2,6 +2,7 @@
 from fastapi import FastAPI, Depends
 from fastapi.middleware.cors import CORSMiddleware
 from app.auth import require_beta_user
+from app.invite import router as admin_router
 
 app = FastAPI(title="Asobi Auth App (Minimum)")
 
@@ -19,6 +20,9 @@ app.add_middleware(
     allow_methods=["*"],
     allow_headers=["*"],
 )
+
+# 管理API
+app.include_router(admin_router)
 
 @app.get("/health")
 async def health():


### PR DESCRIPTION
## Summary
- Firestore を用いた招待台帳とCloud Loggingを追加
- 管理者用招待登録APIを実装

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c7c4fd7fe083319bc0de58f8542b7d