### PR TITLE
feat: add invite-based authentication database schema

### DIFF
--- a/asobi-db/ddl.sql
+++ b/asobi-db/ddl.sql
@@ -1,0 +1,68 @@
+-- PostgreSQL DDL for invite-based authentication
+
+CREATE EXTENSION IF NOT EXISTS pgcrypto;
+
+CREATE TYPE invite_status AS ENUM (
+    'pending',
+    'accepted',
+    'revoked',
+    'expired'
+);
+
+CREATE TABLE invites (
+    invite_id SERIAL PRIMARY KEY,
+    email VARCHAR(255) NOT NULL UNIQUE,
+    token UUID NOT NULL DEFAULT gen_random_uuid(),
+    status invite_status NOT NULL DEFAULT 'pending',
+    expires_at TIMESTAMPTZ NOT NULL,
+    note TEXT,
+    invited_by VARCHAR(255),
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE TABLE users (
+    user_id BIGSERIAL PRIMARY KEY,
+    firebase_uid TEXT NOT NULL UNIQUE,
+    email VARCHAR(255) NOT NULL UNIQUE,
+    invite_id INTEGER REFERENCES invites(invite_id),
+    role VARCHAR(50) NOT NULL DEFAULT 'beta_user',
+    is_email_verified BOOLEAN NOT NULL DEFAULT FALSE,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE TABLE auth_logs (
+    log_id BIGSERIAL PRIMARY KEY,
+    email VARCHAR(255) NOT NULL,
+    action VARCHAR(50) NOT NULL,
+    invite_id INTEGER REFERENCES invites(invite_id),
+    detail TEXT,
+    logged_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE OR REPLACE FUNCTION update_invites_updated_at()
+RETURNS TRIGGER AS $$
+BEGIN
+  NEW.updated_at = now();
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER trg_invites_updated_at
+BEFORE UPDATE ON invites
+FOR EACH ROW
+EXECUTE FUNCTION update_invites_updated_at();
+
+CREATE OR REPLACE FUNCTION update_users_updated_at()
+RETURNS TRIGGER AS $$
+BEGIN
+  NEW.updated_at = now();
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER trg_users_updated_at
+BEFORE UPDATE ON users
+FOR EACH ROW
+EXECUTE FUNCTION update_users_updated_at();

--- a/asobi-db/dml.sql
+++ b/asobi-db/dml.sql
@@ -1,0 +1,22 @@
+-- Sample data for invite-based authentication
+
+-- Insert invite records
+INSERT INTO invites (email, expires_at, note, invited_by)
+VALUES
+('beta1@example.com', now() + interval '7 day', 'First batch', 'admin1'),
+('beta2@example.com', now() + interval '7 day', 'Second batch', 'admin1'),
+('beta3@example.com', now() - interval '1 day', 'Expired invite', 'admin2');
+
+-- Simulate user signup for the first invite
+INSERT INTO users (firebase_uid, email, invite_id, is_email_verified)
+VALUES
+('uid_001', 'beta1@example.com', 1, true);
+
+-- Log actions
+INSERT INTO auth_logs (email, action, invite_id, detail)
+VALUES
+('beta1@example.com', 'invite_sent', 1, 'Invitation email sent'),
+('beta1@example.com', 'signup_allowed', 1, 'Signup allowed by blocking function'),
+('beta3@example.com', 'signup_denied', 3, 'Invite expired'),
+('beta1@example.com', 'signin_allowed', 1, 'Signin permitted'),
+('beta3@example.com', 'signin_denied', 3, 'Invite expired');


### PR DESCRIPTION
## Summary
- 招待制認証フローに対応したPostgreSQLのDDLとサンプルDMLを追加

## Testing
- `psql --version` (command not found)
- `psql -v ON_ERROR_STOP=1 -f asobi-db/ddl.sql` (command not found)


------
https://chatgpt.com/codex/tasks/task_e_68c7c7bafe1483319470d19471b03e45